### PR TITLE
fix(mcp): replace silent failures with contextual error messages

### DIFF
--- a/packages/mcp-server/src/absorb/http-routes.ts
+++ b/packages/mcp-server/src/absorb/http-routes.ts
@@ -66,7 +66,10 @@ async function proxyToAbsorb(
     headers,
     body: body || undefined,
   });
-  const data = await res.json().catch(() => ({ error: 'Invalid response' }));
+  const data = await res.json().catch(async () => {
+    const text = await res.text().catch(() => '<unreadable>');
+    return { error: `Absorb service at ${ABSORB_URL}${path} returned non-JSON (status ${res.status}): ${text.slice(0, 200)}` };
+  });
   return { status: res.status, data };
 }
 

--- a/packages/mcp-server/src/brittney-lite.ts
+++ b/packages/mcp-server/src/brittney-lite.ts
@@ -785,7 +785,10 @@ async function tryModelScaffold(
   const prompt = `Generate a complete HoloScript .holo scene for: ${description}\nProject type: ${type}${featureStr}\n\nOutput ONLY the HoloScript code. Include composition wrapper, environment block, templates, objects with positions, and a logic block.`;
 
   const raw = await queryOllama(prompt);
-  if (!raw) return null;
+  if (!raw) {
+    console.warn(`[brittney-lite] AI model returned empty response for: "${description.slice(0, 60)}". Check Ollama is running and model is loaded.`);
+    return null;
+  }
 
   const code = stripCodeFences(raw);
 
@@ -794,13 +797,20 @@ async function tryModelScaffold(
     const format = detectFormat(code);
     if (format === 'holo') {
       const result = parseHolo(code);
-      if (result.errors?.length > 0) return null;
+      if (result.errors?.length > 0) {
+        console.warn(`[brittney-lite] Generated .holo has ${result.errors.length} parse errors: ${result.errors.slice(0, 2).map((e: any) => e.message || e).join(', ')}. Returning null — caller should retry or adjust prompt.`);
+        return null;
+      }
     } else {
       const parser = new HoloScriptPlusParser();
       const result = parser.parse(code);
-      if (result.errors?.length > 0) return null;
+      if (result.errors?.length > 0) {
+        console.warn(`[brittney-lite] Generated .hsplus has ${result.errors.length} parse errors: ${result.errors.slice(0, 2).map((e: any) => e.message || e).join(', ')}. Returning null.`);
+        return null;
+      }
     }
-  } catch {
+  } catch (e) {
+    console.warn(`[brittney-lite] Parser crashed on generated code: ${(e as Error)?.message ?? e}. The AI model may have produced invalid syntax.`);
     return null;
   }
 

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -227,7 +227,7 @@ export async function handleTool(name: string, args: Record<string, unknown>): P
     case 'edit_holo': {
       const result = await handleEditHoloTool(name, args);
       if (result !== null) return result;
-      throw new Error('edit_holo handler returned null');
+      throw new Error(`[edit_holo] Handler returned null for tool '${name}' with args: ${JSON.stringify(args).slice(0, 200)}. The edit_holo handler could not process this input — check that the .holo source is valid and the edit operation is supported.`);
     }
 
     // Browser control tools

--- a/packages/mcp-server/src/http-server.ts
+++ b/packages/mcp-server/src/http-server.ts
@@ -126,10 +126,10 @@ if (process.env.DATABASE_URL) {
     `
       )
       .then(() => console.info('[credits] Tables ready'))
-      .catch((e: Error) => console.error('[credits] Migration failed:', e.message));
+      .catch((e: Error) => console.error(`[credits] Migration failed: ${e.message}. Credit tracking will not persist. Check DATABASE_URL and ensure PostgreSQL is reachable.`));
   } catch (err) {
-    console.error('[auth] Failed to initialize PostgreSQL pool:', err);
-    console.warn('[auth] Falling back to in-memory token store');
+    console.error(`[auth] Failed to initialize PostgreSQL pool: ${(err as Error)?.message ?? err}. Verify DATABASE_URL is set and the database is running. Falling back to in-memory token store — tokens will not survive restarts.`);
+    console.warn('[auth] Using in-memory token store (DATABASE_URL connection failed)');
   }
 } else {
   console.warn('[auth] Using in-memory token store (no DATABASE_URL)');
@@ -539,7 +539,8 @@ async function handleToolForA2A(name: string, args: Record<string, unknown>): Pr
   });
 
   if (isError) {
-    throw new Error(typeof result === 'string' ? result : JSON.stringify(result));
+    const detail = typeof result === 'string' ? result : JSON.stringify(result).slice(0, 300);
+    throw new Error(`[A2A task dispatch] Tool execution failed: ${detail}. Check the tool handler and input parameters.`);
   }
   return result;
 }

--- a/packages/mcp-server/src/renderer.ts
+++ b/packages/mcp-server/src/renderer.ts
@@ -310,7 +310,9 @@ export async function renderPreview(options: RenderOptions): Promise<RenderResul
   const thumbnailUrl = `${PLAYGROUND_URL}/api/scene/${scene.id}/thumbnail`;
 
   // Trigger async thumbnail generation (non-blocking)
-  generateThumbnail(scene.id).catch(() => {});
+  generateThumbnail(scene.id).catch((e) =>
+    console.warn(`[renderer] Thumbnail generation failed for scene ${scene.id}: ${(e as Error)?.message ?? e}. Preview will use fallback.`)
+  );
 
   return {
     success: true,
@@ -377,7 +379,9 @@ export async function createShareLink(options: ShareOptions): Promise<ShareResul
   const cardMeta = generateCardMeta(title, description, embedUrl, scene.id);
 
   // Trigger async thumbnail generation
-  generateThumbnail(scene.id).catch(() => {});
+  generateThumbnail(scene.id).catch((e) =>
+    console.warn(`[renderer] Thumbnail generation failed for scene ${scene.id}: ${(e as Error)?.message ?? e}. Preview will use fallback.`)
+  );
 
   return {
     playgroundUrl,


### PR DESCRIPTION
## PR-A of 5 — Error Message Audit

Fixes 9 silent failures in the MCP server where agents proceed not knowing something broke.

### Changes
- `renderer.ts`: `catch(() => {})` → logs scene ID and fallback note
- `handlers.ts`: `edit_holo handler returned null` → includes tool name, args, fix suggestion
- `brittney-lite.ts`: 4 silent `return null` → logs parser errors, model status, retry hints  
- `absorb/http-routes.ts`: `"Invalid response"` → includes URL, status code, response preview
- `http-server.ts`: generic A2A error → includes operation name and detail
- `http-server.ts`: PG pool/migration errors → includes config hints and fallback status

### Pattern
Every error now follows: `[OPERATION] FAILED: what happened. Fix: what to do.`

### Test plan
- [ ] `pnpm build` passes
- [ ] No new lint errors on changed files

Generated with [Claude Code](https://claude.com/claude-code)