### PR TITLE
fix(infra): normalize Dockerfile pnpm version and base image

### DIFF
--- a/infrastructure/Dockerfile.render-service
+++ b/infrastructure/Dockerfile.render-service
@@ -2,8 +2,9 @@
 # Headless Unity/WebGPU/glTF compilation background worker and SOC2 compliant async processing.
 # Based on absorb-service Dockerfile configuration
 
+ARG PNPM_VERSION=8.12.0
 FROM node:20-alpine AS base
-RUN corepack enable && corepack prepare pnpm@8.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Collect all package.json for lockfile resolution
 FROM base AS manifests
@@ -38,7 +39,7 @@ RUN cd services/export-api && npx tsup
 # --- Production stage ---
 FROM node:20-alpine
 
-RUN corepack enable && corepack prepare pnpm@8.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 WORKDIR /app
 

--- a/packages/studio/Dockerfile
+++ b/packages/studio/Dockerfile
@@ -1,6 +1,7 @@
+ARG PNPM_VERSION=8.12.0
 FROM node:20-alpine AS base
 RUN apk add --no-cache libc6-compat dumb-init
-RUN corepack enable && corepack prepare pnpm@8.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # ─── Collect all package.json for lockfile resolution ────────────────────────
 # pnpm install --frozen-lockfile needs every workspace package.json present.

--- a/services/holoscript-net/Dockerfile
+++ b/services/holoscript-net/Dockerfile
@@ -1,6 +1,7 @@
 # Build stage
-FROM node:20-slim AS builder
-RUN corepack enable && corepack prepare pnpm@8.12.0 --activate
+ARG PNPM_VERSION=8.12.0
+FROM node:20-alpine AS builder
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 WORKDIR /app
 COPY package*.json ./
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
@@ -10,8 +11,8 @@ COPY . .
 RUN pnpm run build
 
 # Production stage
-FROM node:20-slim
-RUN corepack enable && corepack prepare pnpm@8.12.0 --activate
+FROM node:20-alpine
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package*.json ./


### PR DESCRIPTION
## Summary
- Standardize all Dockerfiles to use `ARG PNPM_VERSION=8.12.0` instead of hardcoded versions
- Normalize base image to `node:20-alpine` across all services
- Matches workspace `packageManager: pnpm@8.12.0` in package.json

## Files changed
- `infrastructure/Dockerfile.render-service` — hardcoded → ARG
- `packages/studio/Dockerfile` — hardcoded → ARG  
- `services/holoscript-net/Dockerfile` — hardcoded → ARG, `slim` → `alpine`

## Test plan
- [ ] All Docker builds succeed with normalized versions
- [ ] No runtime differences between alpine and slim for these services

🤖 Generated with [Claude Code](https://claude.com/claude-code)