### PR TITLE
feat(plugins): Film/VFX domain plugin

### DIFF
--- a/packages/plugins/film-vfx-plugin/package.json
+++ b/packages/plugins/film-vfx-plugin/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@holoscript/plugin-film-vfx",
+  "version": "1.0.0",
+  "description": "Film/VFX domain plugin for HoloScript — shot lists, color grading, DMX lighting, director AI, and virtual production",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/",
+    "examples/",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "test": "vitest run",
+    "prepublishOnly": "npm run clean && npm run build",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "holoscript",
+    "plugin",
+    "film",
+    "vfx",
+    "virtual-production",
+    "led-wall",
+    "dmx",
+    "color-grading",
+    "director",
+    "shot-list"
+  ],
+  "author": "HoloScript Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brianonbased-dev/HoloScript.git",
+    "directory": "packages/plugins/film-vfx-plugin"
+  },
+  "homepage": "https://github.com/brianonbased-dev/HoloScript#readme",
+  "bugs": {
+    "url": "https://github.com/brianonbased-dev/HoloScript/issues"
+  },
+  "peerDependencies": {
+    "holoscript": "^6.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "@types/node": "^20.0.0",
+    "rimraf": "^5.0.0",
+    "vitest": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {}
+}

--- a/packages/plugins/film-vfx-plugin/src/index.ts
+++ b/packages/plugins/film-vfx-plugin/src/index.ts
@@ -1,0 +1,303 @@
+/**
+ * @holoscript/plugin-film-vfx v1.0.0
+ * Film/VFX domain plugin for HoloScript
+ *
+ * Traits:
+ *   @shot_list         — Shot planning, sequencing, lens/movement
+ *   @color_grade       — Color grading, LUT management, lift/gamma/gain
+ *   @dmx_lighting      — DMX512/Art-Net/sACN fixture control
+ *   @director_ai       — AI blocking, motivation, emotional beats, coverage
+ *   @virtual_production — LED wall ICVFX, frustum, tracking, sync
+ *
+ * The plugin does NOT modify HoloScript core. It provides domain-specific
+ * trait types, handlers, and a compile function for film/VFX verticals.
+ *
+ * @packageDocumentation
+ */
+
+// ============================================================================
+// Trait re-exports
+// ============================================================================
+
+export {
+  type ShotType,
+  type CameraMovement,
+  type LensConfig,
+  type ShotListConfig,
+  type ShotListTraitHandler,
+  createShotListHandler,
+} from './traits/ShotListTrait';
+
+export {
+  type LiftGammaGain,
+  type ColorGradeConfig,
+  type ColorGradeTraitHandler,
+  createColorGradeHandler,
+} from './traits/ColorGradeTrait';
+
+export {
+  type FixtureType,
+  type DMXProtocol,
+  type GoboConfig,
+  type DMXLightingConfig,
+  type DMXLightingTraitHandler,
+  createDMXLightingHandler,
+} from './traits/DMXLightingTrait';
+
+export {
+  type BlockingMark,
+  type EmotionalBeat,
+  type CoverageType,
+  type CoverageRequirement,
+  type DirectorAIConfig,
+  type DirectorAITraitHandler,
+  createDirectorAIHandler,
+} from './traits/DirectorAITrait';
+
+export {
+  type SyncMode,
+  type LEDPanelLayout,
+  type FrustumConfig,
+  type LEDWallConfig,
+  type CameraTrackingConfig,
+  type VirtualProductionConfig,
+  type VirtualProductionTraitHandler,
+  createVirtualProductionHandler,
+} from './traits/VirtualProductionTrait';
+
+// ============================================================================
+// Domain traits (tagged union)
+// ============================================================================
+
+import type { ShotListConfig } from './traits/ShotListTrait';
+import type { ColorGradeConfig } from './traits/ColorGradeTrait';
+import type { DMXLightingConfig } from './traits/DMXLightingTrait';
+import type { DirectorAIConfig } from './traits/DirectorAITrait';
+import type { VirtualProductionConfig } from './traits/VirtualProductionTrait';
+
+export interface ShotListTrait extends ShotListConfig {
+  trait: 'shot_list';
+}
+
+export interface ColorGradeTrait extends ColorGradeConfig {
+  trait: 'color_grade';
+}
+
+export interface DMXLightingTrait extends DMXLightingConfig {
+  trait: 'dmx_lighting';
+}
+
+export interface DirectorAITrait extends DirectorAIConfig {
+  trait: 'director_ai';
+}
+
+export interface VirtualProductionTrait extends VirtualProductionConfig {
+  trait: 'virtual_production';
+}
+
+export type FilmVFXTrait =
+  | ShotListTrait
+  | ColorGradeTrait
+  | DMXLightingTrait
+  | DirectorAITrait
+  | VirtualProductionTrait;
+
+// ============================================================================
+// Compile
+// ============================================================================
+
+export interface FilmVFXCompileOptions {
+  format?: 'holo' | 'edl' | 'otio' | 'json';
+}
+
+/**
+ * Compile film/VFX traits into a target representation.
+ *
+ * - `holo`  — HoloScript .holo composition (default)
+ * - `edl`   — CMX3600 Edit Decision List
+ * - `otio`  — OpenTimelineIO JSON
+ * - `json`  — Raw JSON export
+ */
+export function compile(traits: FilmVFXTrait[], opts: FilmVFXCompileOptions = {}): string {
+  const format = opts.format ?? 'holo';
+
+  switch (format) {
+    case 'holo':
+      return compileToHolo(traits);
+    case 'edl':
+      return compileToEDL(traits);
+    case 'otio':
+      return compileToOTIO(traits);
+    case 'json':
+      return JSON.stringify(traits, null, 2);
+    default:
+      throw new Error(`Unsupported film/VFX format: ${format as string}`);
+  }
+}
+
+function compileToHolo(traits: FilmVFXTrait[]): string {
+  const lines: string[] = ['composition "FilmVFXScene" {'];
+
+  for (const t of traits) {
+    switch (t.trait) {
+      case 'shot_list':
+        lines.push(`  object "Shot_${t.shotId}" @shot_list {`);
+        lines.push(`    scene: ${t.scene}`);
+        lines.push(`    shotType: "${t.shotType}"`);
+        lines.push(`    duration: ${t.duration}`);
+        lines.push(`    lens: { focalLength: ${t.lens.focalLength} }`);
+        lines.push(`    movement: "${t.movement}"`);
+        lines.push('  }');
+        break;
+      case 'color_grade':
+        lines.push(`  object "${t.gradeName ?? 'Grade'}" @color_grade {`);
+        lines.push(`    temperature: ${t.temperature}`);
+        lines.push(`    contrast: ${t.contrast}`);
+        lines.push(`    saturation: ${t.saturation}`);
+        if (t.lut) lines.push(`    lut: "${t.lut}"`);
+        lines.push('  }');
+        break;
+      case 'dmx_lighting':
+        lines.push(`  object "${t.label ?? `Fixture_U${t.universe}_CH${t.channel}`}" @dmx_lighting {`);
+        lines.push(`    universe: ${t.universe}`);
+        lines.push(`    channel: ${t.channel}`);
+        lines.push(`    fixtureType: "${t.fixtureType}"`);
+        lines.push(`    intensity: ${t.intensity}`);
+        lines.push(`    color: [${t.color.join(', ')}]`);
+        lines.push('  }');
+        break;
+      case 'director_ai':
+        lines.push(`  object "Director_${t.sceneId}" @director_ai {`);
+        lines.push(`    blocking: ${t.blocking.length} marks`);
+        lines.push(`    coverage: ${t.coverage.length} requirements`);
+        lines.push(`    beats: ${t.emotionalBeats.length}`);
+        lines.push('  }');
+        break;
+      case 'virtual_production':
+        lines.push(`  object "VP_${t.stageId}" @virtual_production {`);
+        lines.push(`    walls: ${t.walls.length}`);
+        lines.push(`    syncMode: "${t.syncMode}"`);
+        lines.push(`    frameRate: ${t.frameRate}`);
+        lines.push(`    tracking: "${t.tracking.system}"`);
+        lines.push('  }');
+        break;
+    }
+  }
+
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function compileToEDL(traits: FilmVFXTrait[]): string {
+  const lines: string[] = ['TITLE: HoloScript Film/VFX Export', ''];
+  let eventNum = 1;
+  let tcOffset = 0;
+
+  const shotTraits = traits.filter((t): t is ShotListTrait => t.trait === 'shot_list');
+
+  for (const shot of shotTraits) {
+    const tcIn = formatTimecode(tcOffset, 24);
+    const tcOut = formatTimecode(tcOffset + shot.duration, 24);
+    lines.push(
+      `${String(eventNum).padStart(3, '0')}  ` +
+        `AX       V     C        ` +
+        `${tcIn} ${tcOut} ${tcIn} ${tcOut}`
+    );
+    lines.push(`* SHOT: ${shot.shotId} | ${shot.shotType} | ${shot.movement} | ${shot.lens.focalLength}mm`);
+    if (shot.description) lines.push(`* NOTE: ${shot.description}`);
+    lines.push('');
+    tcOffset += shot.duration;
+    eventNum++;
+  }
+
+  return lines.join('\n');
+}
+
+function compileToOTIO(traits: FilmVFXTrait[]): string {
+  const shotTraits = traits.filter((t): t is ShotListTrait => t.trait === 'shot_list');
+
+  const timeline = {
+    OTIO_SCHEMA: 'Timeline.1',
+    name: 'HoloScript Film/VFX Export',
+    tracks: {
+      OTIO_SCHEMA: 'Stack.1',
+      children: [
+        {
+          OTIO_SCHEMA: 'Track.1',
+          name: 'V1',
+          kind: 'Video',
+          children: shotTraits.map((shot) => ({
+            OTIO_SCHEMA: 'Clip.1',
+            name: `Shot_${shot.shotId}`,
+            source_range: {
+              OTIO_SCHEMA: 'TimeRange.1',
+              start_time: { OTIO_SCHEMA: 'RationalTime.1', value: 0, rate: 24 },
+              duration: { OTIO_SCHEMA: 'RationalTime.1', value: shot.duration * 24, rate: 24 },
+            },
+            metadata: {
+              holoscript: {
+                shotType: shot.shotType,
+                movement: shot.movement,
+                focalLength: shot.lens.focalLength,
+                scene: shot.scene,
+              },
+            },
+          })),
+        },
+      ],
+    },
+  };
+
+  return JSON.stringify(timeline, null, 2);
+}
+
+function formatTimecode(seconds: number, fps: number): string {
+  const totalFrames = Math.round(seconds * fps);
+  const h = Math.floor(totalFrames / (fps * 3600));
+  const m = Math.floor((totalFrames % (fps * 3600)) / (fps * 60));
+  const s = Math.floor((totalFrames % (fps * 60)) / fps);
+  const f = totalFrames % fps;
+  return [h, m, s, f].map((v) => String(v).padStart(2, '0')).join(':');
+}
+
+// ============================================================================
+// Plugin registration
+// ============================================================================
+
+import { createShotListHandler } from './traits/ShotListTrait';
+import { createColorGradeHandler } from './traits/ColorGradeTrait';
+import { createDMXLightingHandler } from './traits/DMXLightingTrait';
+import { createDirectorAIHandler } from './traits/DirectorAITrait';
+import { createVirtualProductionHandler } from './traits/VirtualProductionTrait';
+
+/** All trait handlers provided by this plugin */
+export const traitHandlers = [
+  createShotListHandler(),
+  createColorGradeHandler(),
+  createDMXLightingHandler(),
+  createDirectorAIHandler(),
+  createVirtualProductionHandler(),
+] as const;
+
+/** Plugin metadata for PluginLifecycleManager registration */
+export const pluginMeta = {
+  id: 'film-vfx',
+  name: 'Film/VFX',
+  version: VERSION,
+  description: 'Shot lists, color grading, DMX lighting, director AI, and virtual production for HoloScript',
+  traits: ['shot_list', 'color_grade', 'dmx_lighting', 'director_ai', 'virtual_production'],
+  compileFormats: ['holo', 'edl', 'otio', 'json'],
+} as const;
+
+// ============================================================================
+// Version
+// ============================================================================
+
+export const VERSION = '1.0.0';
+
+export default {
+  VERSION,
+  pluginMeta,
+  traitHandlers,
+  compile,
+};

--- a/packages/plugins/film-vfx-plugin/src/traits/ColorGradeTrait.ts
+++ b/packages/plugins/film-vfx-plugin/src/traits/ColorGradeTrait.ts
@@ -1,0 +1,110 @@
+/**
+ * @color_grade trait — Color grading and look management for film/VFX
+ *
+ * Supports LUT application, primary corrections (lift/gamma/gain),
+ * and secondary adjustments (temperature, tint, contrast, saturation).
+ * Designed for real-time preview in virtual production and offline grading.
+ *
+ * @module @holoscript/plugin-film-vfx
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LiftGammaGain {
+  /** Lift (shadows) — RGB offset, each channel -1 to 1 */
+  lift: [number, number, number];
+  /** Gamma (midtones) — RGB multiplier, each channel 0 to 4 */
+  gamma: [number, number, number];
+  /** Gain (highlights) — RGB multiplier, each channel 0 to 4 */
+  gain: [number, number, number];
+}
+
+export interface ColorGradeConfig {
+  /** LUT file path or built-in name */
+  lut?: string;
+  /** LUT intensity (0-1, blend with ungraded) */
+  lutIntensity?: number;
+  /** Color temperature in Kelvin (2000-12000) */
+  temperature: number;
+  /** Tint shift green-magenta (-100 to 100) */
+  tint: number;
+  /** Contrast adjustment (-100 to 100) */
+  contrast: number;
+  /** Saturation multiplier (0 = desaturated, 1 = normal, 2 = oversaturated) */
+  saturation: number;
+  /** Lift/Gamma/Gain color wheels */
+  liftGammaGain: LiftGammaGain;
+  /** Exposure offset in stops (-5 to 5) */
+  exposure?: number;
+  /** Highlight recovery (0-100) */
+  highlights?: number;
+  /** Shadow recovery (0-100) */
+  shadows?: number;
+  /** Vibrance (0-100, protects skin tones) */
+  vibrance?: number;
+  /** Film grain intensity (0-1) */
+  grain?: number;
+  /** Vignette intensity (0-1) */
+  vignette?: number;
+  /** Grade name for look management */
+  gradeName?: string;
+  /** CDL (Color Decision List) export compatibility */
+  cdlCompatible?: boolean;
+}
+
+// ============================================================================
+// Trait Handler
+// ============================================================================
+
+export interface ColorGradeTraitHandler {
+  name: 'color_grade';
+  defaultConfig: ColorGradeConfig;
+  onAttach(entity: unknown, config: ColorGradeConfig): void;
+  onDetach(entity: unknown): void;
+  onUpdate(entity: unknown, config: Partial<ColorGradeConfig>): void;
+  onEvent(entity: unknown, event: string, payload: unknown): void;
+}
+
+export function createColorGradeHandler(): ColorGradeTraitHandler {
+  return {
+    name: 'color_grade',
+    defaultConfig: {
+      temperature: 6500,
+      tint: 0,
+      contrast: 0,
+      saturation: 1,
+      liftGammaGain: {
+        lift: [0, 0, 0],
+        gamma: [1, 1, 1],
+        gain: [1, 1, 1],
+      },
+      exposure: 0,
+      highlights: 0,
+      shadows: 0,
+      vibrance: 50,
+      cdlCompatible: true,
+    },
+    onAttach(entity: unknown, config: ColorGradeConfig): void {
+      // Apply LUT and color corrections to render pipeline
+      void entity;
+      void config;
+    },
+    onDetach(entity: unknown): void {
+      // Remove grade from render pipeline, restore defaults
+      void entity;
+    },
+    onUpdate(entity: unknown, config: Partial<ColorGradeConfig>): void {
+      // Real-time grade adjustment (scrub, live preview)
+      void entity;
+      void config;
+    },
+    onEvent(entity: unknown, event: string, payload: unknown): void {
+      // Handle events: 'snapshot_grade', 'apply_lut', 'reset', 'export_cdl'
+      void entity;
+      void event;
+      void payload;
+    },
+  };
+}

--- a/packages/plugins/film-vfx-plugin/src/traits/DMXLightingTrait.ts
+++ b/packages/plugins/film-vfx-plugin/src/traits/DMXLightingTrait.ts
@@ -1,0 +1,125 @@
+/**
+ * @dmx_lighting trait — DMX512 lighting control for film/VFX and stage
+ *
+ * Controls DMX universes, fixture channels, intensity, color, and gobos.
+ * Supports Art-Net and sACN protocols for integration with physical
+ * lighting rigs and LED walls.
+ *
+ * @module @holoscript/plugin-film-vfx
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FixtureType =
+  | 'fresnel'
+  | 'led_panel'
+  | 'led_tube'
+  | 'moving_head'
+  | 'par'
+  | 'profile'
+  | 'strobe'
+  | 'cyc_light'
+  | 'follow_spot'
+  | 'practical'
+  | 'hmi'
+  | 'tungsten'
+  | 'rgb_wash'
+  | 'pixel_bar';
+
+export type DMXProtocol = 'dmx512' | 'artnet' | 'sacn';
+
+export interface GoboConfig {
+  /** Gobo wheel slot index */
+  slot: number;
+  /** Gobo rotation speed (degrees/sec, 0 = static) */
+  rotation?: number;
+  /** Gobo name/description */
+  name?: string;
+}
+
+export interface DMXLightingConfig {
+  /** DMX universe number (1-based) */
+  universe: number;
+  /** Start channel address (1-512) */
+  channel: number;
+  /** Number of channels this fixture uses */
+  channelCount: number;
+  /** Fixture type */
+  fixtureType: FixtureType;
+  /** Master intensity (0-255 DMX, or 0-100 percent) */
+  intensity: number;
+  /** Intensity unit */
+  intensityUnit?: 'dmx' | 'percent';
+  /** RGB color (0-255 per channel) */
+  color: [number, number, number];
+  /** Color temperature in Kelvin (for white fixtures) */
+  colorTemp?: number;
+  /** Gobo configuration (for moving heads / profiles) */
+  gobo?: GoboConfig;
+  /** Pan angle in degrees (for moving heads) */
+  pan?: number;
+  /** Tilt angle in degrees (for moving heads) */
+  tilt?: number;
+  /** Dimmer curve */
+  dimmerCurve?: 'linear' | 'square' | 'inverse_square' | 'scurve';
+  /** DMX protocol for output */
+  protocol?: DMXProtocol;
+  /** Art-Net subnet/universe (if protocol = artnet) */
+  artnetSubnet?: number;
+  /** Fixture label for patch list */
+  label?: string;
+  /** Group assignment (e.g., "key", "fill", "back", "practical") */
+  group?: string;
+}
+
+// ============================================================================
+// Trait Handler
+// ============================================================================
+
+export interface DMXLightingTraitHandler {
+  name: 'dmx_lighting';
+  defaultConfig: DMXLightingConfig;
+  onAttach(entity: unknown, config: DMXLightingConfig): void;
+  onDetach(entity: unknown): void;
+  onUpdate(entity: unknown, config: Partial<DMXLightingConfig>): void;
+  onEvent(entity: unknown, event: string, payload: unknown): void;
+}
+
+export function createDMXLightingHandler(): DMXLightingTraitHandler {
+  return {
+    name: 'dmx_lighting',
+    defaultConfig: {
+      universe: 1,
+      channel: 1,
+      channelCount: 6,
+      fixtureType: 'led_panel',
+      intensity: 255,
+      intensityUnit: 'dmx',
+      color: [255, 255, 255],
+      dimmerCurve: 'linear',
+      protocol: 'dmx512',
+    },
+    onAttach(entity: unknown, config: DMXLightingConfig): void {
+      // Register fixture in DMX universe, allocate channels
+      void entity;
+      void config;
+    },
+    onDetach(entity: unknown): void {
+      // Release DMX channels, zero intensity
+      void entity;
+    },
+    onUpdate(entity: unknown, config: Partial<DMXLightingConfig>): void {
+      // Update DMX channel values in real-time (intensity, color, position)
+      void entity;
+      void config;
+    },
+    onEvent(entity: unknown, event: string, payload: unknown): void {
+      // Handle events: 'blackout', 'full', 'cue_go', 'strobe_on', 'strobe_off', 'park'
+      void entity;
+      void event;
+      void payload;
+    },
+  };
+}

--- a/packages/plugins/film-vfx-plugin/src/traits/DirectorAITrait.ts
+++ b/packages/plugins/film-vfx-plugin/src/traits/DirectorAITrait.ts
@@ -1,0 +1,136 @@
+/**
+ * @director_ai trait — AI-assisted directing for blocking, motivation, and coverage
+ *
+ * Provides structured data for AI-driven scene direction: actor blocking,
+ * character motivation, emotional beats, and coverage requirements.
+ * Integrates with shot_list and virtual_production for automated
+ * pre-visualization and shot planning.
+ *
+ * @module @holoscript/plugin-film-vfx
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BlockingMark {
+  /** Mark label (e.g., "A1", "B2") */
+  mark: string;
+  /** Position in scene space [x, y, z] meters */
+  position: [number, number, number];
+  /** Facing direction in degrees (0 = camera) */
+  facing: number;
+  /** Time in scene when actor hits this mark (seconds) */
+  atTime: number;
+  /** Action at this mark */
+  action?: string;
+}
+
+export interface EmotionalBeat {
+  /** Beat identifier */
+  id: string;
+  /** Time range in scene [start, end] seconds */
+  timeRange: [number, number];
+  /** Primary emotion */
+  emotion: string;
+  /** Intensity (0-1) */
+  intensity: number;
+  /** Transition from previous beat */
+  transition?: 'sudden' | 'gradual' | 'building' | 'releasing';
+  /** Director note */
+  note?: string;
+}
+
+export type CoverageType =
+  | 'master'
+  | 'single'
+  | 'two_shot'
+  | 'over_shoulder'
+  | 'insert'
+  | 'reaction'
+  | 'establishing'
+  | 'cutaway';
+
+export interface CoverageRequirement {
+  /** Coverage type needed */
+  type: CoverageType;
+  /** Subject(s) this coverage is for */
+  subjects: string[];
+  /** Whether this coverage is mandatory */
+  mandatory: boolean;
+  /** Linked shot ID (if already planned) */
+  shotId?: string;
+  /** Status */
+  status: 'planned' | 'captured' | 'missing';
+}
+
+export interface DirectorAIConfig {
+  /** Scene identifier */
+  sceneId: string;
+  /** Scene description / log line */
+  description?: string;
+  /** Actor blocking marks */
+  blocking: BlockingMark[];
+  /** Character motivations (character name -> motivation text) */
+  motivation: Record<string, string>;
+  /** Emotional beats for the scene */
+  emotionalBeats: EmotionalBeat[];
+  /** Coverage requirements */
+  coverage: CoverageRequirement[];
+  /** Scene tone / mood keywords */
+  tone?: string[];
+  /** Reference films/scenes for AI context */
+  references?: string[];
+  /** Pacing target: beats per minute */
+  pacingBPM?: number;
+  /** Auto-generate shot suggestions from blocking + coverage */
+  autoSuggestShots?: boolean;
+}
+
+// ============================================================================
+// Trait Handler
+// ============================================================================
+
+export interface DirectorAITraitHandler {
+  name: 'director_ai';
+  defaultConfig: DirectorAIConfig;
+  onAttach(entity: unknown, config: DirectorAIConfig): void;
+  onDetach(entity: unknown): void;
+  onUpdate(entity: unknown, config: Partial<DirectorAIConfig>): void;
+  onEvent(entity: unknown, event: string, payload: unknown): void;
+}
+
+export function createDirectorAIHandler(): DirectorAITraitHandler {
+  return {
+    name: 'director_ai',
+    defaultConfig: {
+      sceneId: 'scene_001',
+      blocking: [],
+      motivation: {},
+      emotionalBeats: [],
+      coverage: [],
+      autoSuggestShots: true,
+    },
+    onAttach(entity: unknown, config: DirectorAIConfig): void {
+      // Initialize director AI context for the scene
+      void entity;
+      void config;
+    },
+    onDetach(entity: unknown): void {
+      // Clean up director context
+      void entity;
+    },
+    onUpdate(entity: unknown, config: Partial<DirectorAIConfig>): void {
+      // Update blocking, beats, or coverage; re-evaluate shot suggestions
+      void entity;
+      void config;
+    },
+    onEvent(entity: unknown, event: string, payload: unknown): void {
+      // Handle events: 'suggest_shots', 'validate_coverage', 'analyze_pacing',
+      // 'mark_coverage_captured', 'generate_storyboard'
+      void entity;
+      void event;
+      void payload;
+    },
+  };
+}

--- a/packages/plugins/film-vfx-plugin/src/traits/ShotListTrait.ts
+++ b/packages/plugins/film-vfx-plugin/src/traits/ShotListTrait.ts
@@ -1,0 +1,130 @@
+/**
+ * @shot_list trait — Shot planning and sequencing for film/VFX productions
+ *
+ * Defines shot type, duration, lens, and camera movement for each take.
+ * Used by director AI and virtual production pipelines to pre-visualize
+ * and execute camera choreography.
+ *
+ * @module @holoscript/plugin-film-vfx
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ShotType =
+  | 'extreme_wide'
+  | 'wide'
+  | 'medium_wide'
+  | 'medium'
+  | 'medium_close'
+  | 'close'
+  | 'extreme_close'
+  | 'over_the_shoulder'
+  | 'pov'
+  | 'insert'
+  | 'cutaway'
+  | 'two_shot'
+  | 'establishing';
+
+export type CameraMovement =
+  | 'static'
+  | 'pan'
+  | 'tilt'
+  | 'dolly'
+  | 'crane'
+  | 'steadicam'
+  | 'handheld'
+  | 'drone'
+  | 'tracking'
+  | 'zoom'
+  | 'whip_pan'
+  | 'rack_focus';
+
+export interface LensConfig {
+  /** Focal length in mm */
+  focalLength: number;
+  /** T-stop (cinematic f-stop) */
+  tStop?: number;
+  /** Focus distance in meters */
+  focusDistance?: number;
+  /** Anamorphic lens enabled */
+  anamorphic?: boolean;
+  /** Lens model name for metadata */
+  model?: string;
+}
+
+export interface ShotListConfig {
+  /** Shot identifier (e.g., "1A", "2B") */
+  shotId: string;
+  /** Scene number */
+  scene: number;
+  /** Shot type framing */
+  shotType: ShotType;
+  /** Duration in seconds */
+  duration: number;
+  /** Lens configuration */
+  lens: LensConfig;
+  /** Camera movement type */
+  movement: CameraMovement;
+  /** Movement speed (0-1, 0=static, 1=fastest) */
+  movementSpeed?: number;
+  /** Description / director notes */
+  description?: string;
+  /** Subject(s) in frame */
+  subjects?: string[];
+  /** Transition to next shot */
+  transition?: 'cut' | 'dissolve' | 'wipe' | 'fade_in' | 'fade_out' | 'match_cut';
+  /** Take number (for multi-take tracking) */
+  take?: number;
+  /** Priority for coverage requirements */
+  priority?: 'essential' | 'preferred' | 'optional';
+}
+
+// ============================================================================
+// Trait Handler
+// ============================================================================
+
+export interface ShotListTraitHandler {
+  name: 'shot_list';
+  defaultConfig: ShotListConfig;
+  onAttach(entity: unknown, config: ShotListConfig): void;
+  onDetach(entity: unknown): void;
+  onUpdate(entity: unknown, config: Partial<ShotListConfig>): void;
+  onEvent(entity: unknown, event: string, payload: unknown): void;
+}
+
+export function createShotListHandler(): ShotListTraitHandler {
+  return {
+    name: 'shot_list',
+    defaultConfig: {
+      shotId: '1A',
+      scene: 1,
+      shotType: 'medium',
+      duration: 5,
+      lens: { focalLength: 50 },
+      movement: 'static',
+      priority: 'essential',
+    },
+    onAttach(entity: unknown, config: ShotListConfig): void {
+      // Register shot in the shot list registry for the scene
+      void entity;
+      void config;
+    },
+    onDetach(entity: unknown): void {
+      // Remove shot from registry
+      void entity;
+    },
+    onUpdate(entity: unknown, config: Partial<ShotListConfig>): void {
+      // Update shot parameters (lens change, reframing, etc.)
+      void entity;
+      void config;
+    },
+    onEvent(entity: unknown, event: string, payload: unknown): void {
+      // Handle events: 'mark_take', 'print_take', 'advance_shot', 'cut'
+      void entity;
+      void event;
+      void payload;
+    },
+  };
+}

--- a/packages/plugins/film-vfx-plugin/src/traits/VirtualProductionTrait.ts
+++ b/packages/plugins/film-vfx-plugin/src/traits/VirtualProductionTrait.ts
@@ -1,0 +1,184 @@
+/**
+ * @virtual_production trait — LED wall virtual production (VP) configuration
+ *
+ * Manages LED volume/wall configuration, camera frustum tracking,
+ * inner/outer frustum rendering, genlock sync, and stage calibration.
+ * Designed for ICVFX (In-Camera Visual Effects) workflows.
+ *
+ * @module @holoscript/plugin-film-vfx
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type SyncMode =
+  | 'genlock'
+  | 'framelock'
+  | 'freerun'
+  | 'timecode'
+  | 'ntp';
+
+export type LEDPanelLayout =
+  | 'flat_wall'
+  | 'curved_wall'
+  | 'three_wall'
+  | 'full_volume'
+  | 'ceiling_floor'
+  | 'custom';
+
+export interface FrustumConfig {
+  /** Camera sensor width in mm */
+  sensorWidth: number;
+  /** Camera sensor height in mm */
+  sensorHeight: number;
+  /** Current focal length in mm */
+  focalLength: number;
+  /** Near clip plane in meters */
+  nearClip: number;
+  /** Far clip plane in meters */
+  farClip: number;
+  /** Inner frustum overscan percentage (0-50) */
+  overscan?: number;
+  /** Multi-sample anti-aliasing level for inner frustum */
+  msaa?: 1 | 2 | 4 | 8;
+}
+
+export interface LEDWallConfig {
+  /** Wall identifier */
+  id: string;
+  /** Panel layout type */
+  layout: LEDPanelLayout;
+  /** Physical dimensions in meters [width, height] */
+  dimensions: [number, number];
+  /** Panel pixel resolution [horizontal, vertical] */
+  resolution: [number, number];
+  /** Pixel pitch in mm */
+  pixelPitch: number;
+  /** Wall position relative to stage origin [x, y, z] meters */
+  position: [number, number, number];
+  /** Wall rotation [pitch, yaw, roll] degrees */
+  rotation: [number, number, number];
+  /** Curve radius in meters (for curved walls, 0 = flat) */
+  curveRadius?: number;
+  /** nDisplay cluster node name */
+  nDisplayNode?: string;
+}
+
+export interface CameraTrackingConfig {
+  /** Tracking system type */
+  system: 'stype' | 'ncam' | 'mo-sys' | 'optitrack' | 'vive' | 'antilatency' | 'custom';
+  /** Tracking latency in ms (for compensation) */
+  latency?: number;
+  /** Tracking offset from camera body [x, y, z] mm */
+  offset?: [number, number, number];
+  /** Enable lens encoder data */
+  lensEncoding?: boolean;
+  /** Enable lens distortion correction */
+  distortionCorrection?: boolean;
+}
+
+export interface VirtualProductionConfig {
+  /** Stage identifier */
+  stageId: string;
+  /** LED wall configurations */
+  walls: LEDWallConfig[];
+  /** Camera frustum configuration */
+  frustum: FrustumConfig;
+  /** Camera tracking system */
+  tracking: CameraTrackingConfig;
+  /** Synchronization mode */
+  syncMode: SyncMode;
+  /** Target frame rate */
+  frameRate: number;
+  /** Color space for LED output */
+  colorSpace?: 'srgb' | 'rec709' | 'rec2020' | 'aces_cg' | 'dci_p3';
+  /** Enable light card system */
+  lightCards?: boolean;
+  /** Inner frustum render priority (higher = more GPU) */
+  innerFrustumPriority?: number;
+  /** Outer frustum quality (0-1, lower = faster) */
+  outerFrustumQuality?: number;
+  /** Enable green screen compositing for ceiling gaps */
+  greenScreenFill?: boolean;
+  /** Stage calibration data file path */
+  calibrationFile?: string;
+  /** Enable real-time color calibration */
+  realtimeColorCalibration?: boolean;
+}
+
+// ============================================================================
+// Trait Handler
+// ============================================================================
+
+export interface VirtualProductionTraitHandler {
+  name: 'virtual_production';
+  defaultConfig: VirtualProductionConfig;
+  onAttach(entity: unknown, config: VirtualProductionConfig): void;
+  onDetach(entity: unknown): void;
+  onUpdate(entity: unknown, config: Partial<VirtualProductionConfig>): void;
+  onEvent(entity: unknown, event: string, payload: unknown): void;
+}
+
+export function createVirtualProductionHandler(): VirtualProductionTraitHandler {
+  return {
+    name: 'virtual_production',
+    defaultConfig: {
+      stageId: 'stage_main',
+      walls: [
+        {
+          id: 'main_wall',
+          layout: 'curved_wall',
+          dimensions: [20, 6],
+          resolution: [7680, 2160],
+          pixelPitch: 2.6,
+          position: [0, 3, -10],
+          rotation: [0, 0, 0],
+          curveRadius: 12,
+        },
+      ],
+      frustum: {
+        sensorWidth: 36,
+        sensorHeight: 24,
+        focalLength: 35,
+        nearClip: 0.1,
+        farClip: 1000,
+        overscan: 10,
+        msaa: 4,
+      },
+      tracking: {
+        system: 'stype',
+        latency: 1,
+        lensEncoding: true,
+        distortionCorrection: true,
+      },
+      syncMode: 'genlock',
+      frameRate: 23.976,
+      colorSpace: 'aces_cg',
+      lightCards: true,
+      innerFrustumPriority: 10,
+      outerFrustumQuality: 0.5,
+    },
+    onAttach(entity: unknown, config: VirtualProductionConfig): void {
+      // Initialize VP stage: connect walls, start tracking, configure frustum
+      void entity;
+      void config;
+    },
+    onDetach(entity: unknown): void {
+      // Disconnect walls, stop tracking, release GPU resources
+      void entity;
+    },
+    onUpdate(entity: unknown, config: Partial<VirtualProductionConfig>): void {
+      // Update frustum, tracking, sync mode, or wall config in real-time
+      void entity;
+      void config;
+    },
+    onEvent(entity: unknown, event: string, payload: unknown): void {
+      // Handle events: 'calibrate', 'snapshot', 'record_start', 'record_stop',
+      // 'switch_environment', 'blackout_walls', 'freeze_frame'
+      void entity;
+      void event;
+      void payload;
+    },
+  };
+}

--- a/packages/plugins/film-vfx-plugin/tsconfig.json
+++ b/packages/plugins/film-vfx-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary
New domain plugin: `@holoscript/plugin-film-vfx` with 5 traits:
- `@shot_list`: 13 shot types, 12 camera movements, lens config
- `@color_grade`: LUT, lift/gamma/gain, CDL compatibility
- `@dmx_lighting`: DMX universe/channel, 14 fixture types, Art-Net/sACN
- `@director_ai`: blocking marks, motivation map, emotional beats, coverage
- `@virtual_production`: LED wall config, camera tracking, genlock sync, ACES

Output formats: HoloScript, EDL/CMX3600, OpenTimelineIO, JSON

## Test plan
- [ ] Plugin loads and registers all 5 traits
- [ ] Each trait's defaultConfig is valid
- [ ] Compile to all 4 output formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)