### PR TITLE
fix(core): correct executeVisualMetadata import path — unblocks Railway deploy

### DIFF
--- a/packages/core/src/runtime/node-type-registry.ts
+++ b/packages/core/src/runtime/node-type-registry.ts
@@ -64,7 +64,6 @@ import {
   executeNarrative as executeNarrativePure,
   executeQuest as executeQuestPure,
   executeDialogue as executeDialoguePure,
-  executeVisualMetadata as executeVisualMetadataPure,
 } from './narrative-executors';
 import {
   executeFunction as executeFunctionPure,
@@ -93,6 +92,7 @@ import { executeHoloComposition as executeHoloCompositionPure } from './holo-com
 import {
   executeSystem as executeSystemPure,
   executeCoreConfig as executeCoreConfigPure,
+  executeVisualMetadata as executeVisualMetadataPure,
 } from './system-executors';
 
 // Slice 31/32/33 runtime modules — used via the RuntimeDispatcher's build*Ctx methods.


### PR DESCRIPTION
## Summary
- **One-line import-path fix**: `executeVisualMetadata` moved from `./narrative-executors` block (where it doesn't exist) to `./system-executors` block (where the function actually lives at `system-executors.ts:116`)
- **Root cause**: handler-registry refactor (03af94939, W1-T4 slice 34) guessed the wrong module. Slice 16's comment at `HoloScriptRuntime.ts:1645-1646` explicitly states `executeVisualMetadata` was extracted to `system-executors` — the refactor just wrote the wrong path
- **Impact**: every Railway mcp-server deploy since 2026-04-23 ~17:00 PDT has failed at `build-core-stack-no-dts.sh`. Prod serving ~19h-old build; 3 consecutive FAILED deploys in past 4 hours (confirmed via Railway deployment log d4553a4b-…). Task_sspn ("fix closed but NOT observable in production") tracks the downstream effect

## Test plan
- [x] `npx tsup` (the exact build Railway's Dockerfile runs) completes with `⚡️ Build success` in ~50s on this branch. Pre-fix, errored in <2s at entry resolution
- [ ] After merge: watch next Railway auto-deploy from main succeed → prod `/health` uptime resets + `version` bumps

## Blast radius
- Pure import-path correction. Zero runtime behavior change — the executor function itself was always present, only its import was pointing at the wrong module
- 1 file changed, 1 insertion, 1 deletion
- Unblocks 4 security commits waiting on `deploy/w087-vertex-c` (W.087 vertex C /members, /sovereign/migrate founder-gate, claimedByTag anchor, W.085 cap raise)

## Non-goals
- Not investigating why no CI test caught this. The characterization suite evidently doesn't exercise the `visual_metadata` dispatch path — separate task.