### PR TITLE
security: W.087 vertex C + hardening pass (5 commits)

### DIFF
--- a/packages/core/src/editor/PropertyGrid.ts
+++ b/packages/core/src/editor/PropertyGrid.ts
@@ -60,6 +60,23 @@ export class PropertyGrid {
   private groups: Map<string, PropertyGroupConfig> = new Map();
   private maxHistorySize: number = 100;
 
+  private syncLegacyNumericAliases(target: Record<string, unknown>): void {
+    // Backward compat for legacy callers/tests expecting vec-like [0]/[1]/[2]
+    if ('x' in target && !('0' in target)) {
+      Object.defineProperty(target, '0', { value: target.x, writable: true, enumerable: false });
+    }
+    if ('y' in target && !('1' in target)) {
+      Object.defineProperty(target, '1', { value: target.y, writable: true, enumerable: false });
+    }
+    if ('z' in target && !('2' in target)) {
+      Object.defineProperty(target, '2', { value: target.z, writable: true, enumerable: false });
+    }
+
+    if ('x' in target && '0' in target) (target as Record<number, unknown>)[0] = target.x;
+    if ('y' in target && '1' in target) (target as Record<number, unknown>)[1] = target.y;
+    if ('z' in target && '2' in target) (target as Record<number, unknown>)[2] = target.z;
+  }
+
   /**
    * Register property descriptors for a component type
    */
@@ -78,7 +95,9 @@ export class PropertyGrid {
    * Set values for a specific target (entity/component)
    */
   setValues(targetId: string, values: Record<string, unknown>): void {
-    this.values.set(targetId, { ...values });
+    const snapshot = { ...values };
+    this.syncLegacyNumericAliases(snapshot);
+    this.values.set(targetId, snapshot);
   }
 
   /**
@@ -110,6 +129,7 @@ export class PropertyGrid {
     }
 
     target[key] = newValue;
+    this.syncLegacyNumericAliases(target);
   }
 
   /**
@@ -137,6 +157,7 @@ export class PropertyGrid {
     const target = this.values.get(change.targetId);
     if (target) {
       target[change.key] = change.oldValue;
+      this.syncLegacyNumericAliases(target);
     }
     return change;
   }

--- a/packages/framework/src/__tests__/board-ops.test.ts
+++ b/packages/framework/src/__tests__/board-ops.test.ts
@@ -61,20 +61,35 @@ describe('addTasksToBoard', () => {
   });
 
   it('emits warning when description is truncated', () => {
-    const longDescription = 'x'.repeat(1300);
+    // W.085 fix (2026-04-24): cap raised 1000 → 2000 to unify with the
+    // suggestion-description cap and reduce false-friction on security
+    // audit tasks (~3 reproductions 2026-04-23 → 2026-04-24).
+    const longDescription = 'x'.repeat(2300);
     const { added, warnings } = addTasksToBoard([], [], [
       { title: 'Long desc task', description: longDescription, source: 't', priority: 1 },
     ]);
 
     expect(added).toHaveLength(1);
-    expect(added[0].description).toHaveLength(1000);
+    expect(added[0].description).toHaveLength(2000);
     expect(warnings).toEqual([
       {
         title: 'Long desc task',
         reason: 'description_truncated',
-        originalLength: 1300,
-        keptLength: 1000,
+        originalLength: 2300,
+        keptLength: 2000,
       },
     ]);
+  });
+
+  it('accepts descriptions up to the 2000-char cap without warning', () => {
+    // Boundary regression: W.085 fix must not introduce off-by-one at the cap.
+    const exactlyCapped = 'y'.repeat(2000);
+    const { added, warnings } = addTasksToBoard([], [], [
+      { title: 'Exactly cap', description: exactlyCapped, source: 't', priority: 1 },
+    ]);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].description).toHaveLength(2000);
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/packages/framework/src/board/board-ops.ts
+++ b/packages/framework/src/board/board-ops.ts
@@ -297,7 +297,13 @@ export function addTasksToBoard(
     }
 
     const rawDescription = String(t.description || '');
-    const normalizedDescription = rawDescription.slice(0, 1000);
+    // Cap unified with the suggestion-description cap at line 367 (2000).
+    // W.085 post-mortem: agents repeatedly hit the old 1000 cap while filing
+    // security-audit tasks (~3 reproductions 2026-04-23 to 2026-04-24). The
+    // warning signal already existed; raising the cap reduces false friction
+    // without changing the signal shape — callers still get `warnings[]`
+    // on overflow, just at a higher threshold.
+    const normalizedDescription = rawDescription.slice(0, 2000);
     if (rawDescription.length > normalizedDescription.length) {
       warnings.push({
         title,

--- a/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
@@ -4130,6 +4130,123 @@ describe('HoloMesh HTTP Routes', () => {
     });
   });
 
+  // ── Sovereign Migrate (founder-override gate) ──
+  //
+  // task_1777050402454_28wq (2026-04-24): POST /api/holomesh/sovereign/migrate
+  // must not let non-founder callers fabricate migration records for other
+  // agents by supplying body.agentId. Non-founders always get caller.id in
+  // migration.agentId; founders may override for legitimate simulation.
+  describe('POST /api/holomesh/sovereign/migrate', () => {
+    let nonFounderApiKey: string;
+    let nonFounderAgentId: string;
+    let counter = 0;
+
+    async function registerAgent(name: string): Promise<{ apiKey: string; agentId: string }> {
+      const uniqueName = `${name}-${++counter}-${Math.random().toString(36).slice(2, 8)}`;
+      const req = mockReq('POST', '/api/holomesh/register', { name: uniqueName });
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/register');
+      if (res._status !== 201) throw new Error(`Register failed: ${JSON.stringify(res._body)}`);
+      return { apiKey: res._body.agent.api_key, agentId: res._body.agent.id };
+    }
+
+    beforeEach(async () => {
+      const agent = await registerAgent('migrate-nonfounder');
+      nonFounderApiKey = agent.apiKey;
+      nonFounderAgentId = agent.agentId;
+    });
+
+    it('non-founder: body.agentId=<other> is IGNORED and migration.agentId = caller.id', async () => {
+      const victimId = 'agent_victim_9999';
+
+      const req = mockReq(
+        'POST',
+        '/api/holomesh/sovereign/migrate',
+        { agentId: victimId, fromCluster: 'cluster_a', toCluster: 'cluster_b' },
+        { authorization: `Bearer ${nonFounderApiKey}` }
+      );
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/sovereign/migrate');
+
+      expect(res._status).toBe(200);
+      expect(res._body.success).toBe(true);
+      // The core assertion: body.agentId was IGNORED — migration.agentId is caller's id,
+      // not the attacker-supplied victim id.
+      expect(res._body.migration.agentId).toBe(nonFounderAgentId);
+      expect(res._body.migration.agentId).not.toBe(victimId);
+      expect(res._body.migration.impersonated).toBe(false);
+      // signedBy/signedById agree with the coerced agentId.
+      expect(res._body.migration.signedById).toBe(nonFounderAgentId);
+    });
+
+    it('non-founder: omitting body.agentId still yields migration.agentId = caller.id', async () => {
+      const req = mockReq(
+        'POST',
+        '/api/holomesh/sovereign/migrate',
+        { fromCluster: 'cluster_1', toCluster: 'cluster_2' },
+        { authorization: `Bearer ${nonFounderApiKey}` }
+      );
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/sovereign/migrate');
+
+      expect(res._status).toBe(200);
+      expect(res._body.migration.agentId).toBe(nonFounderAgentId);
+      expect(res._body.migration.impersonated).toBe(false);
+    });
+
+    it('founder: body.agentId=<other> is HONORED but response flags impersonated=true', async () => {
+      // HOLOSCRIPT_API_KEY=test-api-key resolves to isFounder via env-key fallback.
+      const otherAgentId = 'agent_other_12345';
+
+      const req = mockReq(
+        'POST',
+        '/api/holomesh/sovereign/migrate',
+        { agentId: otherAgentId, fromCluster: 'cluster_a', toCluster: 'cluster_b' },
+        { authorization: `Bearer test-api-key` }
+      );
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/sovereign/migrate');
+
+      expect(res._status).toBe(200);
+      expect(res._body.migration.agentId).toBe(otherAgentId);
+      expect(res._body.migration.impersonated).toBe(true);
+      // signedById differs from migration.agentId — downstream consumers see the split.
+      expect(res._body.migration.signedById).not.toBe(otherAgentId);
+    });
+
+    it('founder: omitting body.agentId defaults to caller.id and impersonated=false', async () => {
+      const req = mockReq(
+        'POST',
+        '/api/holomesh/sovereign/migrate',
+        { fromCluster: 'cluster_1' },
+        { authorization: `Bearer test-api-key` }
+      );
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/sovereign/migrate');
+
+      expect(res._status).toBe(200);
+      expect(res._body.migration.impersonated).toBe(false);
+      // For founder self-migration, agentId equals signedById.
+      expect(res._body.migration.agentId).toBe(res._body.migration.signedById);
+    });
+
+    it('unauthenticated: 401/403 before any migration record is produced', async () => {
+      const req = mockReq(
+        'POST',
+        '/api/holomesh/sovereign/migrate',
+        { agentId: 'agent_victim_0001' }
+        // no authorization header
+      );
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, '/api/holomesh/sovereign/migrate');
+
+      // requireAuth returns 401; the exact code belongs to auth-utils, we only
+      // care that no migration body was returned.
+      expect(res._status).toBeGreaterThanOrEqual(401);
+      expect(res._body?.migration).toBeUndefined();
+    });
+  });
+
   // ── Route Matching ──
 
   describe('Route matching', () => {

--- a/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
@@ -1859,6 +1859,127 @@ describe('HoloMesh HTTP Routes', () => {
       expect(res._body.online[0].ideType).toBe('cursor');
     });
 
+    // ── Members + x402/surface observability (W.087 vertex C) ──
+
+    it('GET /api/holomesh/team/:id/members returns wallet + x402 + surface attribution', async () => {
+      // Create team
+      const createReq = mockReq(
+        'POST',
+        '/api/holomesh/team',
+        { name: `members-${Date.now()}` },
+        { authorization: `Bearer ${ownerApiKey}` }
+      );
+      const createRes = mockRes();
+      await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
+      const tid = createRes._body.team.id;
+      const ic = createRes._body.team.invite_code;
+
+      // Member joins with a surface tag
+      const joinReq = mockReq(
+        'POST',
+        `/api/holomesh/team/${tid}/join`,
+        { invite_code: ic, surface_tag: 'claude-code' },
+        { authorization: `Bearer ${memberApiKey}` }
+      );
+      const joinRes = mockRes();
+      await handleHoloMeshRoute(joinReq, joinRes, `/api/holomesh/team/${tid}/join`);
+      expect(joinRes._status).toBe(200);
+
+      // Member beats with surface_tag
+      const beatReq = mockReq(
+        'POST',
+        `/api/holomesh/team/${tid}/presence`,
+        { ide_type: 'vscode', surface_tag: 'claude-code', status: 'active' },
+        { authorization: `Bearer ${memberApiKey}` }
+      );
+      const beatRes = mockRes();
+      await handleHoloMeshRoute(beatReq, beatRes, `/api/holomesh/team/${tid}/presence`);
+      expect(beatRes._status).toBe(200);
+
+      // GET /members — owner sees both members with wallet + x402Verified + surfaceTag
+      const req = mockReq('GET', `/api/holomesh/team/${tid}/members`, undefined, {
+        authorization: `Bearer ${ownerApiKey}`,
+      });
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, `/api/holomesh/team/${tid}/members`);
+
+      expect(res._status).toBe(200);
+      expect(res._body.success).toBe(true);
+      expect(res._body.teamId).toBe(tid);
+      expect(res._body.count).toBe(2);
+      const owner = res._body.members.find((m: any) => m.agentId === ownerAgentId);
+      const member = res._body.members.find((m: any) => m.agentId === memberAgentId);
+      expect(owner).toBeDefined();
+      expect(member).toBeDefined();
+      // Owner — from POST /team creation, wallet/x402 snapshotted
+      expect(owner.role).toBe('owner');
+      expect(owner.walletAddress).toMatch(/^0x/);
+      expect(typeof owner.x402Verified).toBe('boolean');
+      // Member — joined via /join with surface_tag, online via /presence
+      expect(member.role).toBe('member');
+      expect(member.walletAddress).toMatch(/^0x/);
+      expect(member.surfaceTag).toBe('claude-code');
+      expect(member.online).toBe(true);
+      expect(member.lastHeartbeat).toBeTruthy();
+    });
+
+    it('GET /api/holomesh/team/:id/members 403s non-members', async () => {
+      // Create team with owner, don't let member join
+      const createReq = mockReq(
+        'POST',
+        '/api/holomesh/team',
+        { name: `members-403-${Date.now()}` },
+        { authorization: `Bearer ${ownerApiKey}` }
+      );
+      const createRes = mockRes();
+      await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
+      const tid = createRes._body.team.id;
+
+      const req = mockReq('GET', `/api/holomesh/team/${tid}/members`, undefined, {
+        authorization: `Bearer ${memberApiKey}`,
+      });
+      const res = mockRes();
+      await handleHoloMeshRoute(req, res, `/api/holomesh/team/${tid}/members`);
+
+      expect(res._status).toBe(403);
+    });
+
+    it('GET /api/holomesh/team/:id/presence surfaces wallet + x402Verified + surfaceTag on heartbeat', async () => {
+      const createReq = mockReq(
+        'POST',
+        '/api/holomesh/team',
+        { name: `pres-x402-${Date.now()}` },
+        { authorization: `Bearer ${ownerApiKey}` }
+      );
+      const createRes = mockRes();
+      await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
+      const tid = createRes._body.team.id;
+
+      // Beat with surface_tag declared
+      const beatReq = mockReq(
+        'POST',
+        `/api/holomesh/team/${tid}/presence`,
+        { ide_type: 'claude-code', surface_tag: 'claude-code' },
+        { authorization: `Bearer ${ownerApiKey}` }
+      );
+      const beatRes = mockRes();
+      await handleHoloMeshRoute(beatReq, beatRes, `/api/holomesh/team/${tid}/presence`);
+      expect(beatRes._status).toBe(200);
+      expect(beatRes._body.presence.surfaceTag).toBe('claude-code');
+      expect(beatRes._body.presence.walletAddress).toMatch(/^0x/);
+      expect(typeof beatRes._body.presence.x402Verified).toBe('boolean');
+
+      // Read back via GET
+      const getReq = mockReq('GET', `/api/holomesh/team/${tid}/presence`, undefined, {
+        authorization: `Bearer ${ownerApiKey}`,
+      });
+      const getRes = mockRes();
+      await handleHoloMeshRoute(getReq, getRes, `/api/holomesh/team/${tid}/presence`);
+      expect(getRes._status).toBe(200);
+      expect(getRes._body.online[0].surfaceTag).toBe('claude-code');
+      expect(getRes._body.online[0].walletAddress).toMatch(/^0x/);
+    });
+
     // ── Messaging ──
 
     it('POST /api/holomesh/team/:id/message sends team message', async () => {

--- a/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
@@ -2502,7 +2502,9 @@ describe('HoloMesh HTTP Routes', () => {
       await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
       const tid = createRes._body.team.id;
 
-      const longDescription = 'd'.repeat(1200);
+      // W.085 fix (2026-04-24): cap raised 1000 → 2000. Input sized above the
+      // new cap so truncation still fires and warning shape is asserted.
+      const longDescription = 'd'.repeat(2200);
       const req = mockReq(
         'POST',
         `/api/holomesh/team/${tid}/board`,
@@ -2520,8 +2522,8 @@ describe('HoloMesh HTTP Routes', () => {
         {
           title: 'Warn me',
           reason: 'description_truncated',
-          originalLength: 1200,
-          keptLength: 1000,
+          originalLength: 2200,
+          keptLength: 2000,
         },
       ]);
     });

--- a/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
@@ -2704,6 +2704,90 @@ describe('HoloMesh HTTP Routes', () => {
       expect(entry.commitHash).toBe('def5678');
     });
 
+    // W.087 vertex B+C hardening — SECURITY: once an agent is registered with
+    // surface_tag on RegisteredAgent (see 01424bcd6), body.claimedByTag /
+    // body.completedByTag / body.deleterTag cannot override it. Closes
+    // task_1777050402454_50h3 (same vuln class as surfaceTag spoofing).
+    it('PATCH /board/:taskId refuses body.claimedByTag / completedByTag / deleterTag override when caller.surfaceTag is set', async () => {
+      // 1. Register a victim agent with surface_tag=claude-code
+      const regReq = mockReq('POST', '/api/holomesh/register', {
+        name: `tag-spoof-${Date.now()}`,
+        surface_tag: 'claude-code',
+      });
+      const regRes = mockRes();
+      await handleHoloMeshRoute(regReq, regRes, '/api/holomesh/register');
+      expect([200, 201]).toContain(regRes._status);
+      const victimApiKey = regRes._body.agent.api_key;
+
+      // 2. Create a team + task under the victim
+      const createReq = mockReq(
+        'POST',
+        '/api/holomesh/team',
+        { name: `tag-spoof-team-${Date.now()}` },
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const createRes = mockRes();
+      await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
+      const tid = createRes._body.team.id;
+
+      const addReq = mockReq(
+        'POST',
+        `/api/holomesh/team/${tid}/board`,
+        { tasks: [{ title: 'tag-spoof-target', description: 't', priority: 1 }] },
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const addRes = mockRes();
+      await handleHoloMeshRoute(addReq, addRes, `/api/holomesh/team/${tid}/board`);
+      const taskId = addRes._body.tasks[0].id;
+
+      // 3. Claim with body.claimedByTag=copilot (spoof attempt)
+      const claimReq = mockReq(
+        'PATCH',
+        `/api/holomesh/team/${tid}/board/${taskId}`,
+        { action: 'claim', claimedByTag: 'copilot' }, // ← attempted spoof
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const claimRes = mockRes();
+      await handleHoloMeshRoute(claimReq, claimRes, `/api/holomesh/team/${tid}/board/${taskId}`);
+      expect(claimRes._status).toBe(200);
+      // Server-stored surfaceTag (claude-code) MUST win over body.claimedByTag (copilot)
+      expect(claimRes._body.task.claimedByTag).toBe('claude-code');
+      expect(claimRes._body.task.claimedByTag).not.toBe('copilot');
+      expect(claimRes._body.claimedAs.surfaceTag).toBe('claude-code');
+
+      // 4. Done with body.completedByTag=cursor (spoof attempt)
+      const doneReq = mockReq(
+        'PATCH',
+        `/api/holomesh/team/${tid}/board/${taskId}`,
+        {
+          action: 'done',
+          summary: 'tag-spoof-test',
+          commit: 'abcdef0',
+          completedByTag: 'cursor', // ← attempted spoof
+        },
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const doneRes = mockRes();
+      await handleHoloMeshRoute(doneReq, doneRes, `/api/holomesh/team/${tid}/board/${taskId}`);
+      expect(doneRes._status).toBe(200);
+      expect(doneRes._body.task.completedByTag).toBe('claude-code');
+      expect(doneRes._body.task.completedByTag).not.toBe('cursor');
+      expect(doneRes._body.completedAs.surfaceTag).toBe('claude-code');
+
+      // 5. Done-log projection also shows the register-time tag, not the spoof
+      const logReq = mockReq(
+        'GET',
+        `/api/holomesh/team/${tid}/board/done?limit=10`,
+        undefined,
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const logRes = mockRes();
+      await handleHoloMeshRoute(logReq, logRes, `/api/holomesh/team/${tid}/board/done?limit=10`);
+      expect(logRes._status).toBe(200);
+      const entry = logRes._body.entries.find((e: { taskId: string }) => e.taskId === taskId);
+      expect(entry?.completedByTag).toBe('claude-code');
+    });
+
     it('PATCH /board/:taskId claim/done without tags still works (backward compat)', async () => {
       // Pre-tag callers must continue to function. Tags default to undefined
       // and are omitted from the response when absent.

--- a/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/__tests__/http-routes.test.ts
@@ -1980,6 +1980,60 @@ describe('HoloMesh HTTP Routes', () => {
       expect(getRes._body.online[0].walletAddress).toMatch(/^0x/);
     });
 
+    // W.087 vertex C hardening — SECURITY: surfaceTag spoofing defense-in-depth.
+    // surfaceTag is snapshotted on RegisteredAgent at /register time; subsequent
+    // /presence heartbeats cannot reassign it via body.surface_tag. See
+    // task_1777049263971_imm1 (filed + closed in one arc).
+    it('POST /api/holomesh/team/:id/presence refuses to let body.surface_tag override the register-time snapshot', async () => {
+      // 1. Register a fresh agent declaring surface_tag=claude-code
+      const regReq = mockReq('POST', '/api/holomesh/register', {
+        name: `spoof-test-${Date.now()}`,
+        surface_tag: 'claude-code',
+      });
+      const regRes = mockRes();
+      await handleHoloMeshRoute(regReq, regRes, '/api/holomesh/register');
+      expect([200, 201]).toContain(regRes._status);
+      const victimApiKey = regRes._body.agent.api_key;
+
+      // 2. Create a team under that agent
+      const createReq = mockReq(
+        'POST',
+        '/api/holomesh/team',
+        { name: `spoof-team-${Date.now()}` },
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const createRes = mockRes();
+      await handleHoloMeshRoute(createReq, createRes, '/api/holomesh/team');
+      expect(createRes._status).toBe(201);
+      const tid = createRes._body.team.id;
+
+      // 3. POST /presence trying to claim surface_tag=copilot (spoof attempt)
+      const beatReq = mockReq(
+        'POST',
+        `/api/holomesh/team/${tid}/presence`,
+        { ide_type: 'vscode', surface_tag: 'copilot' }, // ← attempted spoof
+        { authorization: `Bearer ${victimApiKey}` }
+      );
+      const beatRes = mockRes();
+      await handleHoloMeshRoute(beatReq, beatRes, `/api/holomesh/team/${tid}/presence`);
+      expect(beatRes._status).toBe(200);
+      // Server-stored surfaceTag from /register MUST win.
+      expect(beatRes._body.presence.surfaceTag).toBe('claude-code');
+      expect(beatRes._body.presence.surfaceTag).not.toBe('copilot');
+
+      // 4. Also verify /members projection surfaces the register-time tag
+      const membersReq = mockReq('GET', `/api/holomesh/team/${tid}/members`, undefined, {
+        authorization: `Bearer ${victimApiKey}`,
+      });
+      const membersRes = mockRes();
+      await handleHoloMeshRoute(membersReq, membersRes, `/api/holomesh/team/${tid}/members`);
+      expect(membersRes._status).toBe(200);
+      const selfMember = membersRes._body.members.find(
+        (m: { agentId: string; surfaceTag?: string }) => m.agentId === regRes._body.agent.id
+      );
+      expect(selfMember?.surfaceTag).toBe('claude-code');
+    });
+
     // ── Messaging ──
 
     it('POST /api/holomesh/team/:id/message sends team message', async () => {

--- a/packages/mcp-server/src/holomesh/board-tools.ts
+++ b/packages/mcp-server/src/holomesh/board-tools.ts
@@ -427,12 +427,13 @@ async function handleBoardAdd(args: Record<string, unknown>): Promise<Record<str
       ? (result as any).warnings
       : tasks.flatMap((t) => {
           const raw = String((t as Record<string, unknown>).description || '');
-          if (raw.length <= 1000) return [];
+          // In sync with board-ops.ts:300 cap (W.085 fix raised 1000→2000).
+          if (raw.length <= 2000) return [];
           return [{
             title: String((t as Record<string, unknown>).title || '').slice(0, 200),
             reason: 'description_truncated' as const,
             originalLength: raw.length,
-            keptLength: 1000,
+            keptLength: 2000,
           }];
         });
     team.taskBoard = result.updatedBoard;
@@ -588,12 +589,13 @@ async function handleScout(args: Record<string, unknown>): Promise<Record<string
       ? (result as any).warnings
       : scopedTasks.flatMap((t: { title?: string; description?: string }) => {
           const raw = String(t.description || '');
-          if (raw.length <= 1000) return [];
+          // In sync with board-ops.ts:300 cap (W.085 fix raised 1000→2000).
+          if (raw.length <= 2000) return [];
           return [{
             title: String(t.title || '').slice(0, 200),
             reason: 'description_truncated' as const,
             originalLength: raw.length,
-            keptLength: 1000,
+            keptLength: 2000,
           }];
         });
     team.taskBoard = result.updatedBoard;

--- a/packages/mcp-server/src/holomesh/routes/board-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/board-routes.ts
@@ -438,13 +438,22 @@ export async function handleBoardRoutes(
 
     const isFirst = !presenceMap.has(caller.id);
     // Carry wallet + x402 verification + surface tag on every heartbeat so
-    // GET /presence distinguishes per-surface x402 seats. Surface tag is
-    // declared by the caller on each beat (body.surface_tag); falls back to
-    // the team member's stored surfaceTag snapshot when omitted.
+    // GET /presence distinguishes per-surface x402 seats.
+    //
+    // Surface tag precedence (defense-in-depth against spoofing):
+    //   1. caller.surfaceTag   — server-stored, snapshotted at /register
+    //   2. teamMember.surfaceTag — snapshot from the join record
+    //   3. body.surface_tag    — only for legacy agents that predate (1)
+    //
+    // Once an agent is registered with a surface, subsequent heartbeats
+    // cannot reassign it via request body. Body is fallback-only.
     const teamMember = team.members.find((m) => m.agentId === caller.id);
     const declaredSurfaceTag = typeof body.surface_tag === 'string'
       ? (body.surface_tag as string)
       : undefined;
+    const resolvedSurfaceTag = caller.surfaceTag
+      ?? teamMember?.surfaceTag
+      ?? declaredSurfaceTag;
     const entry: TeamPresenceEntry = {
       agentId: caller.id,
       agentName: caller.name,
@@ -453,7 +462,7 @@ export async function handleBoardRoutes(
       lastHeartbeat: new Date().toISOString(),
       walletAddress: caller.walletAddress,
       x402Verified: caller.x402Verified === true,
-      surfaceTag: declaredSurfaceTag || teamMember?.surfaceTag,
+      surfaceTag: resolvedSurfaceTag,
     };
     presenceMap.set(caller.id, entry);
 

--- a/packages/mcp-server/src/holomesh/routes/board-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/board-routes.ts
@@ -175,12 +175,13 @@ export async function handleBoardRoutes(
       ? (result as any).warnings
       : (tasksBody as Array<{ title?: string; description?: string }>).flatMap((t) => {
           const raw = String(t.description || '');
-          if (raw.length <= 1000) return [];
+          // Kept in sync with board-ops.ts:300 cap (W.085 fix raised 1000→2000).
+          if (raw.length <= 2000) return [];
           return [{
             title: String(t.title || '').slice(0, 200),
             reason: 'description_truncated' as const,
             originalLength: raw.length,
-            keptLength: 1000,
+            keptLength: 2000,
           }];
         });
     team.taskBoard = result.updatedBoard;

--- a/packages/mcp-server/src/holomesh/routes/board-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/board-routes.ts
@@ -312,14 +312,26 @@ export async function handleBoardRoutes(
     let result: any;
     let eventType: string = '';
 
-    // Surface-attribution tags from request body. These let multiple surfaces
-    // sharing one HoloMesh API key (S.IDENT legacy `antigravity-seed`) be
-    // distinguished in UI/done-log while per-surface key issuance is pending
-    // (task_1776820645291_*). The server-derived `caller.id`/`caller.name`
-    // remain the authoritative identity; tags are purely advisory labels.
-    const claimedByTag = typeof body.claimedByTag === 'string' ? body.claimedByTag : undefined;
-    const completedByTag = typeof body.completedByTag === 'string' ? body.completedByTag : undefined;
-    const deleterTag = typeof body.deleterTag === 'string' ? body.deleterTag : undefined;
+    // Surface-attribution tags. With W.087 vertex C (01424bcd6) + vertex B
+    // (51558fa) live, `caller.surfaceTag` is the server-stored snapshot from
+    // /register time and is the authoritative source. The caller is also the
+    // actor for claim/done/delete — the tag must describe their own surface,
+    // not an arbitrary string chosen per-request.
+    //
+    // Body-declared tags are fallback-only for legacy agents that registered
+    // before `surfaceTag` was persisted on `RegisteredAgent`. A caller with a
+    // server-stored surfaceTag CANNOT override it via body — defense-in-depth
+    // against surface impersonation in the done-log / board UI.
+    //
+    // Still advisory in the sense that caller.id/caller.name remain the
+    // authoritative identity; what changed is that the tag field can no
+    // longer be arbitrarily reassigned per-request.
+    const claimedByTag = caller.surfaceTag
+      ?? (typeof body.claimedByTag === 'string' ? body.claimedByTag : undefined);
+    const completedByTag = caller.surfaceTag
+      ?? (typeof body.completedByTag === 'string' ? body.completedByTag : undefined);
+    const deleterTag = caller.surfaceTag
+      ?? (typeof body.deleterTag === 'string' ? body.deleterTag : undefined);
     const deleteReason = typeof body.reason === 'string' ? body.reason.slice(0, 500) : undefined;
 
     switch (action) {

--- a/packages/mcp-server/src/holomesh/routes/board-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/board-routes.ts
@@ -1,17 +1,18 @@
 import type http from 'http';
-import { 
-  teamStore, 
+import {
+  teamStore,
   teamPresenceStore,
   teamMessageStore,
   teamFeedStore,
-  persistTeamStore 
+  agentKeyStore,
+  persistTeamStore
 } from '../state';
-import { 
-  json, 
-  parseJsonBody, 
+import {
+  json,
+  parseJsonBody,
   parseQuery,
-  extractParam, 
-  getTeamMember, 
+  extractParam,
+  getTeamMember,
   hasTeamPermission,
   requireTeamAccess,
   pruneStalePresence
@@ -38,7 +39,7 @@ import {
   type SlotRole,
   type SuggestionCategory
 } from '@holoscript/framework';
-import type { Team, TeamPresenceEntry, TeamMessage, TeamFeedItem } from '../types';
+import type { Team, TeamPresenceEntry, TeamMessage, TeamFeedItem, RegisteredAgent } from '../types';
 
 const MAX_FEED_QUERY = 100;
 
@@ -436,12 +437,23 @@ export async function handleBoardRoutes(
     }
 
     const isFirst = !presenceMap.has(caller.id);
+    // Carry wallet + x402 verification + surface tag on every heartbeat so
+    // GET /presence distinguishes per-surface x402 seats. Surface tag is
+    // declared by the caller on each beat (body.surface_tag); falls back to
+    // the team member's stored surfaceTag snapshot when omitted.
+    const teamMember = team.members.find((m) => m.agentId === caller.id);
+    const declaredSurfaceTag = typeof body.surface_tag === 'string'
+      ? (body.surface_tag as string)
+      : undefined;
     const entry: TeamPresenceEntry = {
       agentId: caller.id,
       agentName: caller.name,
       ideType: body.ide_type as string,
       status: (body.status as any) || 'active',
       lastHeartbeat: new Date().toISOString(),
+      walletAddress: caller.walletAddress,
+      x402Verified: caller.x402Verified === true,
+      surfaceTag: declaredSurfaceTag || teamMember?.surfaceTag,
     };
     presenceMap.set(caller.id, entry);
 
@@ -457,6 +469,65 @@ export async function handleBoardRoutes(
     const online = Array.from(presenceMap.values());
 
     json(res, 200, { success: true, online, presence: entry, online_count: online.length });
+    return true;
+  }
+
+  // GET /api/holomesh/team/:id/members — W.087 vertex C
+  //
+  // Membership listing with wallet / x402 / surface attribution. Ships as the
+  // canonical "who is on this team" endpoint so agents can disambiguate
+  // per-surface x402 seats from the shared founder key (which was the
+  // blind-spot that drove F.022 and S.IDENT Dim-1 open for weeks).
+  //
+  // Response fields per member (all required keys present even when empty):
+  //   - agentId, agentName, role, joinedAt — always set (from TeamMember)
+  //   - walletAddress — backfilled from agentKeyStore when the TeamMember
+  //     snapshot is missing it (legacy members joined before types.ts shipped
+  //     these fields in this commit)
+  //   - x402Verified — ditto (inferred from RegisteredAgent.x402Verified)
+  //   - surfaceTag — from TeamMember snapshot or, when absent, the last
+  //     observed presence entry's surfaceTag (heartbeats declare this)
+  //
+  // Auth: team membership (same gate as GET /presence). Non-members 403.
+  if (pathname.match(/^\/api\/holomesh\/team\/[^/]+\/members$/) && method === 'GET') {
+    const access = requireTeamAccess(req, res, url);
+    if (!access) return true;
+    const { teamId } = access;
+    const team = teamStore.get(teamId)!;
+
+    const presenceMap = teamPresenceStore.get(teamId);
+
+    // Build an agentId → RegisteredAgent backfill index (by id, not apiKey).
+    const byAgentId = new Map<string, RegisteredAgent>();
+    for (const a of agentKeyStore.values()) {
+      byAgentId.set(a.id, a);
+    }
+
+    const members = team.members.map((m) => {
+      const registered = byAgentId.get(m.agentId);
+      const presence = presenceMap?.get(m.agentId);
+      const walletAddress = m.walletAddress ?? registered?.walletAddress;
+      const x402Verified = m.x402Verified ?? (registered?.x402Verified === true);
+      const surfaceTag = m.surfaceTag ?? presence?.surfaceTag;
+      return {
+        agentId: m.agentId,
+        agentName: m.agentName,
+        role: m.role,
+        joinedAt: m.joinedAt,
+        walletAddress,
+        x402Verified,
+        surfaceTag,
+        online: Boolean(presence),
+        lastHeartbeat: presence?.lastHeartbeat,
+      };
+    });
+
+    json(res, 200, {
+      success: true,
+      teamId,
+      count: members.length,
+      members,
+    });
     return true;
   }
 

--- a/packages/mcp-server/src/holomesh/routes/knowledge-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/knowledge-routes.ts
@@ -677,12 +677,29 @@ export async function handleKnowledgeRoutes(
   }
 
   // POST /api/holomesh/sovereign/migrate — simulate agent state migration via LifePods
+  //
+  // SECURITY (task_1777050402454_28wq, 2026-04-24): body.agentId is honored ONLY
+  // for founders. Non-founder callers CANNOT specify agentId — it is always
+  // coerced to caller.id. Rationale: endpoint returns a simulated signed
+  // migration record (snapshotHash + signedBy); a non-founder caller supplying
+  // body.agentId=<victim-id> would produce a payload where migration.agentId
+  // diverges from signedBy, letting downstream consumers who read agentId
+  // before signedBy attribute the migration to the victim. Founders retain
+  // override for legitimate cross-agent migration simulation (e.g. admin
+  // tooling testing migration flows on behalf of another agent). The response
+  // now surfaces `impersonated: true` when a founder overrides, so consumers
+  // can distinguish self-signed migrations from founder-simulated ones.
   if (pathname === '/api/holomesh/sovereign/migrate' && method === 'POST') {
     const caller = requireAuth(req, res);
     if (!caller) return true;
 
     const body = await parseJsonBody(req);
-    const agentId = (body.agentId as string | undefined)?.trim() || caller.id;
+    const requestedAgentId = (body.agentId as string | undefined)?.trim();
+    const impersonated = Boolean(
+      requestedAgentId && caller.isFounder && requestedAgentId !== caller.id,
+    );
+    // Founder-override gate: non-founders always get caller.id regardless of body.agentId.
+    const agentId = caller.isFounder && requestedAgentId ? requestedAgentId : caller.id;
     const fromCluster = (body.fromCluster as string | undefined)?.trim() || 'cluster_1';
     const toCluster = (body.toCluster as string | undefined)?.trim() || 'cluster_2';
     const mode = ((body.mode as string | undefined)?.trim() || 'live-cutover');
@@ -702,6 +719,8 @@ export async function handleKnowledgeRoutes(
         status: 'simulated-complete',
         snapshotHash,
         signedBy: caller.name,
+        signedById: caller.id,
+        impersonated,
         completedAt: new Date().toISOString(),
       },
     });

--- a/packages/mcp-server/src/holomesh/routes/team-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/team-routes.ts
@@ -234,7 +234,7 @@ export async function handleTeamRoutes(
             joinedAt: new Date().toISOString(),
             walletAddress: agent.walletAddress,
             x402Verified: agent.x402Verified === true,
-            surfaceTag: ide,
+            surfaceTag: agent.surfaceTag ?? ide,
           });
           persistTeamStore();
           broadcastToRoom(team.id, {
@@ -482,12 +482,21 @@ export async function handleTeamRoutes(
       const apiKey = `holomesh_sk_${crypto.randomUUID().replace(/-/g, '')}`;
       const wallet = providedWallet ? null : createWalletMaterial();
       const walletAddress = providedWallet || wallet!.address;
+      // Snapshot surface_tag once at /register — downstream handlers will
+      // always prefer this server-stored value over body.surface_tag. An
+      // agent can self-declare whatever it wants at enrollment (low-risk:
+      // that's just the agent labeling itself), but it cannot retroactively
+      // impersonate another surface via later requests.
+      const registerSurfaceTag = typeof body.surface_tag === 'string'
+        ? ((body.surface_tag as string).trim() || undefined)
+        : undefined;
       const agent: RegisteredAgent = {
         id: `agent_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         apiKey,
         walletAddress,
         name,
         x402Verified: isX402Path,
+        surfaceTag: registerSurfaceTag,
         traits: Array.isArray(body.traits) ? body.traits : [],
         reputation: 0,
         profile: {
@@ -720,9 +729,12 @@ export async function handleTeamRoutes(
       return true;
     }
 
-    const joinSurfaceTag = typeof body.surface_tag === 'string'
-      ? (body.surface_tag as string)
-      : (typeof body.ide_type === 'string' ? (body.ide_type as string) : undefined);
+    // Server-stored surfaceTag (from /register) takes precedence — body fields
+    // are only fallback for legacy agents that registered before surfaceTag
+    // was snapshotted on RegisteredAgent.
+    const joinSurfaceTag = caller.surfaceTag
+      ?? (typeof body.surface_tag === 'string' ? (body.surface_tag as string) : undefined)
+      ?? (typeof body.ide_type === 'string' ? (body.ide_type as string) : undefined);
     team.members.push({
       agentId: caller.id,
       agentName: caller.name,
@@ -830,10 +842,16 @@ export async function handleTeamRoutes(
     if (!team) { json(res, 404, { error: 'Team not found' }); return true; }
     if (!getTeamMember(team, caller.id)) { json(res, 403, { error: 'Not a member' }); return true; }
     const body = await parseJsonBody(req);
+    // caller.surfaceTag (snapshotted at /register) wins over body.surface_tag.
+    // Body is only honored when the caller predates this change (no server-
+    // stored surfaceTag) and no join-time TeamMember snapshot exists.
     const declaredSurfaceTag = typeof body.surface_tag === 'string'
       ? (body.surface_tag as string)
       : undefined;
     const teamMember = team.members.find((m) => m.agentId === caller.id);
+    const resolvedSurfaceTag = caller.surfaceTag
+      ?? teamMember?.surfaceTag
+      ?? declaredSurfaceTag;
     const entry = {
       agentId: caller.id,
       agentName: caller.name,
@@ -842,7 +860,7 @@ export async function handleTeamRoutes(
       lastHeartbeat: new Date().toISOString(),
       walletAddress: caller.walletAddress,
       x402Verified: caller.x402Verified === true,
-      surfaceTag: declaredSurfaceTag || teamMember?.surfaceTag,
+      surfaceTag: resolvedSurfaceTag,
     } as import('../types').TeamPresenceEntry;
     if (!teamPresenceStore.has(teamId)) teamPresenceStore.set(teamId, new Map());
     teamPresenceStore.get(teamId)!.set(caller.id, entry);

--- a/packages/mcp-server/src/holomesh/routes/team-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/team-routes.ts
@@ -232,6 +232,9 @@ export async function handleTeamRoutes(
             agentName: agent.name,
             role: 'member' as TeamRole,
             joinedAt: new Date().toISOString(),
+            walletAddress: agent.walletAddress,
+            x402Verified: agent.x402Verified === true,
+            surfaceTag: ide,
           });
           persistTeamStore();
           broadcastToRoom(team.id, {
@@ -484,6 +487,7 @@ export async function handleTeamRoutes(
         apiKey,
         walletAddress,
         name,
+        x402Verified: isX402Path,
         traits: Array.isArray(body.traits) ? body.traits : [],
         reputation: 0,
         profile: {
@@ -625,7 +629,14 @@ export async function handleTeamRoutes(
       ownerName: caller.name,
       inviteCode,
       maxSlots: 20,
-      members: [{ agentId: caller.id, agentName: caller.name, role: 'owner', joinedAt: new Date().toISOString() }],
+      members: [{
+        agentId: caller.id,
+        agentName: caller.name,
+        role: 'owner',
+        joinedAt: new Date().toISOString(),
+        walletAddress: caller.walletAddress,
+        x402Verified: caller.x402Verified === true,
+      }],
       waitlist: [],
       createdAt: new Date().toISOString(),
       taskBoard: [],
@@ -709,11 +720,17 @@ export async function handleTeamRoutes(
       return true;
     }
 
+    const joinSurfaceTag = typeof body.surface_tag === 'string'
+      ? (body.surface_tag as string)
+      : (typeof body.ide_type === 'string' ? (body.ide_type as string) : undefined);
     team.members.push({
       agentId: caller.id,
       agentName: caller.name,
       role: 'member',
-      joinedAt: new Date().toISOString()
+      joinedAt: new Date().toISOString(),
+      walletAddress: caller.walletAddress,
+      x402Verified: caller.x402Verified === true,
+      surfaceTag: joinSurfaceTag,
     });
     persistTeamStore();
 
@@ -813,12 +830,19 @@ export async function handleTeamRoutes(
     if (!team) { json(res, 404, { error: 'Team not found' }); return true; }
     if (!getTeamMember(team, caller.id)) { json(res, 403, { error: 'Not a member' }); return true; }
     const body = await parseJsonBody(req);
+    const declaredSurfaceTag = typeof body.surface_tag === 'string'
+      ? (body.surface_tag as string)
+      : undefined;
+    const teamMember = team.members.find((m) => m.agentId === caller.id);
     const entry = {
       agentId: caller.id,
       agentName: caller.name,
       ideType: (body.ideType as string) || 'unknown',
       status: (body.status as string) || 'active',
       lastHeartbeat: new Date().toISOString(),
+      walletAddress: caller.walletAddress,
+      x402Verified: caller.x402Verified === true,
+      surfaceTag: declaredSurfaceTag || teamMember?.surfaceTag,
     } as import('../types').TeamPresenceEntry;
     if (!teamPresenceStore.has(teamId)) teamPresenceStore.set(teamId, new Map());
     teamPresenceStore.get(teamId)!.set(caller.id, entry);

--- a/packages/mcp-server/src/holomesh/types.ts
+++ b/packages/mcp-server/src/holomesh/types.ts
@@ -619,6 +619,13 @@ export interface RegisteredAgent {
    * SEC-T-Zero fix 2026-04-22 installed the flow; this flag surfaces its result.
    */
   x402Verified?: boolean;
+  /**
+   * Surface tag snapshotted once at /register time from `body.surface_tag`.
+   * Downstream heartbeats and joins use this value; they cannot override it
+   * by re-declaring the field on /presence or /join. Defense-in-depth against
+   * an agent claiming another surface's tag post-enrollment.
+   */
+  surfaceTag?: string;
 }
 
 // --- Social Metadata ---

--- a/packages/mcp-server/src/holomesh/types.ts
+++ b/packages/mcp-server/src/holomesh/types.ts
@@ -457,6 +457,21 @@ export interface TeamMember {
   agentName: string;
   role: TeamRole;
   joinedAt: string;
+  /** Wallet address of the member (snapshot from RegisteredAgent at join time). */
+  walletAddress?: string;
+  /**
+   * True when the member's registration completed the x402 challenge-verified
+   * flow (EIP-712 proof-of-ownership on /register). False or undefined for
+   * legacy path / server-generated wallets.
+   */
+  x402Verified?: boolean;
+  /**
+   * Surface tag captured at join time, e.g. "claude-code", "claude-cursor",
+   * "gemini-antigravity", "copilot-vscode". Informational — the load-bearing
+   * attribution is agentId/walletAddress; this helps humans + audits spot
+   * which IDE seat is which when multiple seats share a wallet family.
+   */
+  surfaceTag?: string;
 }
 
 export interface Team {
@@ -516,6 +531,16 @@ export interface TeamPresenceEntry {
   ideType: string;
   status: 'active' | 'idle' | 'busy' | 'offline';
   lastHeartbeat: string;
+  /** Wallet address of the heartbeating agent (snapshot from RegisteredAgent). */
+  walletAddress?: string;
+  /** True when the agent's wallet ownership was verified via x402 challenge flow at register time. */
+  x402Verified?: boolean;
+  /**
+   * Surface tag declared on the heartbeat, e.g. "claude-code", "cursor-claude".
+   * Body field: `surface_tag`. Distinct from ideType: ideType is the IDE brand
+   * ("vscode"), surfaceTag is the specific agent surface running in it.
+   */
+  surfaceTag?: string;
 }
 
 export interface TeamMessage {
@@ -587,6 +612,13 @@ export interface RegisteredAgent {
   createdAt: string;
   /** Copied from KeyRecord on provisioning — founder agents bypass all creation gates */
   isFounder?: boolean;
+  /**
+   * True when the agent registered via the x402 challenge-verified flow
+   * (client-owned wallet, EIP-712 signature over a server-issued nonce).
+   * False / undefined for legacy path where the server generated the wallet.
+   * SEC-T-Zero fix 2026-04-22 installed the flow; this flag surfaces its result.
+   */
+  x402Verified?: boolean;
 }
 
 // --- Social Metadata ---


### PR DESCRIPTION
## Summary
Five security-mode commits from the 2026-04-24 session, now rebased onto `main` HEAD `acd8202cd` (the core-import fix that just merged via #185). All tests green; ready to merge once Railway confirms the core fix deployed successfully from main.

## Commits (in deploy order)
| SHA | Scope | What |
|---|---|---|
| `3cfa8f875` | feat(holomesh/identity) | W.087 vertex C — `GET /api/holomesh/team/:id/members` endpoint + `walletAddress`/`x402Verified`/`surfaceTag` on presence + join snapshots. `requireTeamAccess` gated. |
| `87cdac73b` | fix(core) | surfaceTag hardening + PropertyGrid legacy aliases (swept-subject commit from peer; code is byte-identical to what I staged for security). |
| `41f63cfdf` | fix(holomesh/security) | `/sovereign/migrate` `body.agentId` gated behind `caller.isFounder`; adds `impersonated`/`signedById` fields to response |
| `4bf01ed79` | fix(holomesh/security) | Anchors `claimedByTag`/`completedByTag`/`deleterTag` to `caller.surfaceTag` — body is fallback-only for legacy agents |
| `073d47080` | fix(board) | W.085 description cap 1000→2000 (unified with suggestion cap); boundary regression test |

## Test plan
- [x] `mcp-server` full sweep **608/608 green** on local main pre-rebase
- [x] `framework` `board-ops` **5/5 green** including new 2000-char boundary test
- [x] `http-routes` suite **155/155 green** including 3 new spoofing-defense tests (surfaceTag, claimedByTag, /sovereign/migrate founder-gate)
- [x] All 5 commits cherry-picked cleanly onto `origin/main` after #185 merge — zero conflicts, only auto-merges on `http-routes.test.ts`
- [ ] Awaiting confirmation Railway deploy `aa5f448a-d0a8-4be9-9876-0ceec4f0a11b` from `main` HEAD succeeds (validates #185 core fix)
- [ ] Post-merge: next Railway auto-deploy ships the 5 commits; verify `GET /api/holomesh/team/:id/members` returns 200 (currently 404 — endpoint not yet deployed)

## Blast radius
- No destructive changes; all 5 commits are additive + defense-in-depth
- Response envelopes unchanged (backward-compat)
- Legacy agents without `surfaceTag` on `RegisteredAgent` fall through to `body.surface_tag`/`body.claimedByTag`/etc. — preserves current behavior

## Related
- Closes: `task_1776992876249_i99g` (audit), `task_1777050402454_28wq`, `task_1777050402454_50h3` (already marked done in-session; this PR ships the code to prod)
- Partially closes: `task_1776992212213_sspn` ("fix closed but NOT observable in production")
- Refs: MEMORY.md `S.IDENT`, W.087 surface-disambiguation triangle (A/B/C + hardening)