### PR TITLE
fix(world-model): make serializeReport produce canonical JSON

### DIFF
--- a/packages/core/src/world-model/AdversarialTrajectoryReport.ts
+++ b/packages/core/src/world-model/AdversarialTrajectoryReport.ts
@@ -86,12 +86,24 @@ export function buildAdversarialTrajectoryReport(
 
 /**
  * Serialize a report to a canonical JSON string. The output is
- * deterministic — key order is fixed and arrays preserve insertion
- * order — so two reports of the same curriculum produce byte-identical
- * JSON (suitable for content-addressable hashing and diff-replay).
+ * deterministic — object keys are sorted recursively and arrays
+ * preserve insertion order — so two reports of the same curriculum
+ * produce byte-identical JSON regardless of how the objects were
+ * constructed (suitable for content-addressable hashing and diff-replay).
  */
 export function serializeReport(report: AdversarialTrajectoryReport): string {
-  return JSON.stringify(report);
+  return JSON.stringify(report, canonicalReplacer);
+}
+
+function canonicalReplacer(_key: string, value: unknown): unknown {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(value as object).sort()) {
+      sorted[k] = (value as Record<string, unknown>)[k];
+    }
+    return sorted;
+  }
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Bug

`serializeReport` in `packages/core/src/world-model/AdversarialTrajectoryReport.ts` used plain `JSON.stringify(report)`.

The docstring explicitly claimed:

> "The output is deterministic — key order is fixed … suitable for content-addressable hashing and diff-replay."

That claim is false. `JSON.stringify` serializes object keys in insertion order. `AdversarialTrajectory` objects contain `payload: Readonly<Record<string, unknown>>` fields inside `ActionStep` and `ObservationStep` — those are explicitly opaque and can have any key insertion order (e.g. when the trajectory arrives from `JSON.parse` of a network response). Two logically identical reports built via different code paths would produce different strings, silently breaking any hash-based comparison.

The existing test only compared `serializeReport(r1)` vs `serializeReport(r2)` where both were built from the same object references, so the bug was not caught.

## Fix

Add a `canonicalReplacer` that sorts object keys recursively before serialization. Arrays are left in insertion order (correct — trajectory order is meaningful). Existing 10 tests still pass.

```ts
function canonicalReplacer(_key: string, value: unknown): unknown {
  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
    const sorted: Record<string, unknown> = {};
    for (const k of Object.keys(value as object).sort()) {
      sorted[k] = (value as Record<string, unknown>)[k];
    }
    return sorted;
  }
  return value;
}
```

## Test plan
- [x] `pnpm --filter @holoscript/core test -- src/world-model/__tests__/AdversarialTrajectoryReport.test.ts` — 10/10 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7XGhk45V16CvQGKeN49x)_