### PR TITLE
feat(core): wire persistent_expired consumer — state-invalidation registry

### DIFF
--- a/packages/core/src/HoloScriptRuntime.ts
+++ b/packages/core/src/HoloScriptRuntime.ts
@@ -139,6 +139,13 @@ import {
   triggerUIEvent as triggerUIEventPure,
   type EventSystemContext,
 } from './runtime/event-system';
+// Capability-gap wire: activate the `persistent_expired` consumer so TTL
+// expiry is observable by readers (state-invalidation registry).
+import {
+  attachStateInvalidationConsumer,
+  defaultStateInvalidationRegistry,
+  type StateInvalidationRegistry,
+} from './runtime/state-invalidation';
 // W1-T4 slice 22: info executors extracted to ./runtime/info-executors
 import {
   executeVisualize as executeVisualizePure,
@@ -386,6 +393,13 @@ export class HoloScriptRuntime implements IParentRuntime {
       this.context.functions.set(name, ((...spreadArgs: HoloScriptValue[]) =>
         fn(spreadArgs)) as unknown as MethodNode);
     }
+
+    // Activate the state-invalidation consumer: subscribe the process-wide
+    // registry to `persistent_expired` so a PersistentTrait TTL expiry is no
+    // longer dispatched into the void. Readers query `runtime.stateInvalidations`
+    // to detect a cleared value and refetch. (Registers once on the persistent
+    // this.eventHandlers map.)
+    attachStateInvalidationConsumer(this.buildEventSystemContext(), defaultStateInvalidationRegistry);
 
     // Attention Graph Query
     // Allows scripts to cull massive global state arrays into top-k attended components efficiently.
@@ -1010,6 +1024,16 @@ export class HoloScriptRuntime implements IParentRuntime {
   // ============================================================================
   // Event System
   // ============================================================================
+
+  /**
+   * Outstanding state invalidations (PersistentTrait TTL expiries). A reader
+   * checks `stateInvalidations.wasInvalidated(key)` before trusting a cached
+   * value and `consume(key)` once it has refetched. Closes the
+   * `persistent_expired`-into-void capability gap.
+   */
+  get stateInvalidations(): StateInvalidationRegistry {
+    return defaultStateInvalidationRegistry;
+  }
 
   /** Construct an EventSystemContext bound to this runtime. (Slice 29) */
   private buildEventSystemContext(): EventSystemContext {

--- a/packages/core/src/__snapshots__/HoloScriptRuntime.characterization.test.ts.snap
+++ b/packages/core/src/__snapshots__/HoloScriptRuntime.characterization.test.ts.snap
@@ -10,7 +10,7 @@ exports[`HoloScriptRuntime characterization (W4-T3 pre-split lock) > evaluateExp
 
 exports[`HoloScriptRuntime characterization (W4-T3 pre-split lock) > evaluateExpression > [L14] boolean expression locks output > L14-exprBoolean 1`] = `"b5bea41b6c623f7c"`;
 
-exports[`HoloScriptRuntime characterization (W4-T3 pre-split lock) > event emission > [L15] emit(event, data) with no handlers is a no-op (locks absence-of-effect) > L15-emitUnhandled 1`] = `"b4be57a6b5ab2773"`;
+exports[`HoloScriptRuntime characterization (W4-T3 pre-split lock) > event emission > [L15] emit(event, data) with no handlers is a no-op (locks absence-of-effect) > L15-emitUnhandled 1`] = `"8b34a7c858d88a58"`;
 
 exports[`HoloScriptRuntime characterization (W4-T3 pre-split lock) > execute(array) sequencing > [L9] sequential execution locks composite result > L9-sequence 1`] = `"4d101c5145caca26"`;
 

--- a/packages/core/src/runtime/state-invalidation.test.ts
+++ b/packages/core/src/runtime/state-invalidation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the state-invalidation registry — the `persistent_expired` consumer.
+ *
+ * Failing-if-broken contract (the gap this closes): before this wiring, a
+ * PersistentTrait TTL expiry emitted `persistent_expired` into the void. These
+ * tests assert a consumer now OBSERVES that expiry. The decisive assertions:
+ *   - a key that expired through the real trait+event-system chain IS recorded;
+ *   - a key that did NOT expire is NOT recorded (no false invalidation).
+ * Both fail against the pre-wiring code where nothing listens.
+ *
+ * **See**: packages/core/src/runtime/state-invalidation.ts, board task
+ *          task_1779744793932_tfmr.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { emit, type EventSystemContext } from './event-system';
+import {
+  StateInvalidationRegistry,
+  attachStateInvalidationConsumer,
+  makeStateInvalidationHandler,
+} from './state-invalidation';
+import { persistentHandler } from '../traits/PersistentTrait';
+import type {
+  AgentRuntime,
+  EventHandler,
+  HoloScriptValue,
+  TraitHandler,
+  UIElementState,
+  VRTraitName,
+} from '../types';
+import type { TraitContext } from '../traits/TraitTypes';
+import type { HSPlusNode } from '../types/HoloScriptPlus';
+
+function makeCtx(overrides: Partial<EventSystemContext> = {}): EventSystemContext {
+  return {
+    eventHandlers: new Map<string, EventHandler[]>(),
+    agentRuntimes: new Map<string, AgentRuntime>(),
+    variables: new Map<string, HoloScriptValue>(),
+    traitHandlers: new Map<VRTraitName, TraitHandler<Record<string, unknown>>>(),
+    uiElements: new Map<string, UIElementState>(),
+    getCurrentScale: () => 1,
+    globalBusEmit: vi.fn(async () => void 0),
+    sendStateMachineEvent: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** A TraitContext whose emit threads back through the event-system, mirroring
+ *  the real runtime's forwardToTraits binding. */
+function traitCtxFor(ctx: EventSystemContext): TraitContext {
+  return {
+    emit: async (e: string, p: HoloScriptValue) => await emit(e, p, ctx),
+    getScaleMultiplier: () => ctx.getCurrentScale() || 1,
+  } as unknown as TraitContext;
+}
+
+let keySeq = 0;
+const uniqueKey = (label: string) => `inval-test-${label}-${Date.now()}-${keySeq++}`;
+
+describe('StateInvalidationRegistry', () => {
+  it('records, queries, and read-and-clears via consume()', () => {
+    const reg = new StateInvalidationRegistry();
+    expect(reg.wasInvalidated('k')).toBe(false);
+    reg.record('k', 'orb-9');
+    expect(reg.wasInvalidated('k')).toBe(true);
+    expect(reg.get('k')?.nodeId).toBe('orb-9');
+    const rec = reg.consume('k');
+    expect(rec?.key).toBe('k');
+    // consume acknowledges → no longer outstanding
+    expect(reg.wasInvalidated('k')).toBe(false);
+  });
+
+  it('ignores empty/invalid keys', () => {
+    const reg = new StateInvalidationRegistry();
+    reg.record('');
+    expect(reg.size).toBe(0);
+  });
+});
+
+describe('makeStateInvalidationHandler', () => {
+  it('records key + nodeId from a persistent_expired payload', () => {
+    const reg = new StateInvalidationRegistry();
+    const handler = makeStateInvalidationHandler(reg);
+    handler({ key: 'kx', node: { id: 'n1' } } as unknown as HoloScriptValue);
+    expect(reg.wasInvalidated('kx')).toBe(true);
+    expect(reg.get('kx')?.nodeId).toBe('n1');
+  });
+
+  it('is a no-op when the payload carries no key', () => {
+    const reg = new StateInvalidationRegistry();
+    const handler = makeStateInvalidationHandler(reg);
+    handler({ node: { id: 'n1' } } as unknown as HoloScriptValue);
+    expect(reg.size).toBe(0);
+  });
+});
+
+describe('attachStateInvalidationConsumer (event-system integration)', () => {
+  it('catches a persistent_expired emitted directly through emit(ctx)', async () => {
+    const ctx = makeCtx();
+    const reg = attachStateInvalidationConsumer(ctx, new StateInvalidationRegistry());
+    await emit('persistent_expired', { key: 'direct-k', node: { id: 'orb-1' } } as unknown as HoloScriptValue, ctx);
+    expect(reg.wasInvalidated('direct-k')).toBe(true);
+    expect(reg.get('direct-k')?.nodeId).toBe('orb-1');
+  });
+});
+
+describe('PersistentTrait expiry → registry (real end-to-end wire)', () => {
+  it('FAILING-IF-BROKEN: an expired persistent key is observed by the consumer', async () => {
+    vi.useFakeTimers();
+    try {
+      const ctx = makeCtx();
+      const reg = attachStateInvalidationConsumer(ctx, new StateInvalidationRegistry());
+      const traitCtx = traitCtxFor(ctx);
+
+      const key = uniqueKey('expired');
+      const node = { id: 'orb-expired' } as unknown as HSPlusNode;
+      const config = { key, defaultValue: 'seed', ttlMs: 1000, backend: 'memory' as const };
+
+      persistentHandler.onAttach!(node, config, traitCtx);
+      expect(reg.wasInvalidated(key)).toBe(false); // not expired yet
+
+      // Advance past the TTL, then tick the trait.
+      vi.setSystemTime(Date.now() + 5000);
+      await persistentHandler.onUpdate!(node, config, traitCtx, 16);
+
+      // The decisive assertion: expiry was no longer silent.
+      expect(reg.wasInvalidated(key)).toBe(true);
+      expect(reg.get(key)?.nodeId).toBe('orb-expired');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT invalidate a key whose TTL has not elapsed (no false positive)', async () => {
+    vi.useFakeTimers();
+    try {
+      const ctx = makeCtx();
+      const reg = attachStateInvalidationConsumer(ctx, new StateInvalidationRegistry());
+      const traitCtx = traitCtxFor(ctx);
+
+      const key = uniqueKey('live');
+      const node = { id: 'orb-live' } as unknown as HSPlusNode;
+      const config = { key, defaultValue: 'seed', ttlMs: 1_000_000, backend: 'memory' as const };
+
+      persistentHandler.onAttach!(node, config, traitCtx);
+      vi.setSystemTime(Date.now() + 1000); // well within the TTL
+      await persistentHandler.onUpdate!(node, config, traitCtx, 16);
+
+      expect(reg.wasInvalidated(key)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/core/src/runtime/state-invalidation.ts
+++ b/packages/core/src/runtime/state-invalidation.ts
@@ -1,0 +1,123 @@
+/**
+ * State-invalidation registry — consumer for `persistent_expired`.
+ *
+ * Closes a Pattern-E capability gap: PersistentTrait.onUpdate emits
+ * `persistent_expired` on TTL expiry (packages/core/src/traits/PersistentTrait.ts),
+ * but NOTHING subscribes to it — the event was dispatched into the void, so a
+ * downstream reader (a cache layer, a Studio panel, an agent re-hydration path)
+ * had no way to learn that a persisted value had been cleared and needed refetch.
+ *
+ * This module registers a real consumer on the runtime event-system
+ * (packages/core/src/runtime/event-system.ts, Stage-4 local listeners) that
+ * records every expiry into a queryable registry. Readers call `wasInvalidated`
+ * / `consume` to detect staleness and trigger a refetch — i.e. it surfaces the
+ * cleared value rather than letting expiry be silent.
+ *
+ * Pure-core: no I/O, no external decoder/renderer dependency. The behavior is
+ * locked by state-invalidation.test.ts with a failing-if-broken assertion
+ * (a key that expired IS recorded; a key that did not is NOT).
+ *
+ * **See**: board task task_1779744793932_tfmr (capability-gap stub-wiring batch).
+ */
+
+import { onEvent, type EventSystemContext } from './event-system';
+import type { HoloScriptValue } from '../types';
+
+/** A single recorded state invalidation. */
+export interface InvalidationRecord {
+  /** The persistence key that expired. */
+  key: string;
+  /** Wall-clock time the invalidation was recorded (ms epoch). */
+  at: number;
+  /** Originating node id, when the event payload carried one. */
+  nodeId?: string;
+}
+
+/**
+ * Tracks keys whose persisted value has been invalidated (TTL expiry).
+ * A reader checks `wasInvalidated(key)` before trusting a cached value and
+ * `consume(key)` once it has refetched (read-and-clear acknowledgement).
+ */
+export class StateInvalidationRegistry {
+  private records = new Map<string, InvalidationRecord>();
+
+  /** Record an invalidation for `key`. No-op on an empty/invalid key. */
+  record(key: string, nodeId?: string): void {
+    if (typeof key !== 'string' || key.length === 0) return;
+    this.records.set(key, { key, at: Date.now(), nodeId });
+  }
+
+  /** True if `key` has an outstanding (unacknowledged) invalidation. */
+  wasInvalidated(key: string): boolean {
+    return this.records.has(key);
+  }
+
+  /** Peek the invalidation record without acknowledging it. */
+  get(key: string): InvalidationRecord | undefined {
+    return this.records.get(key);
+  }
+
+  /**
+   * Read-and-clear: returns the record (if any) and removes it, so a reader
+   * that has refetched the value acknowledges the invalidation exactly once.
+   */
+  consume(key: string): InvalidationRecord | undefined {
+    const record = this.records.get(key);
+    this.records.delete(key);
+    return record;
+  }
+
+  /** All outstanding invalidations. */
+  list(): InvalidationRecord[] {
+    return Array.from(this.records.values());
+  }
+
+  /** Drop all outstanding invalidations. */
+  clear(): void {
+    this.records.clear();
+  }
+
+  /** Count of outstanding invalidations. */
+  get size(): number {
+    return this.records.size;
+  }
+}
+
+/**
+ * Process-wide default registry. Most callers can share this; pass an explicit
+ * registry to {@link attachStateInvalidationConsumer} for isolation (e.g. tests).
+ */
+export const defaultStateInvalidationRegistry = new StateInvalidationRegistry();
+
+/**
+ * The handler registered for `persistent_expired`. Exposed for direct unit
+ * testing without standing up the full event-system dispatch chain.
+ */
+export function makeStateInvalidationHandler(
+  registry: StateInvalidationRegistry,
+): (data?: HoloScriptValue) => void {
+  return (data?: HoloScriptValue) => {
+    const payload = (data ?? {}) as { key?: unknown; node?: { id?: unknown } };
+    if (typeof payload.key === 'string') {
+      const nodeId =
+        payload.node && typeof payload.node.id === 'string' ? payload.node.id : undefined;
+      registry.record(payload.key, nodeId);
+    }
+  };
+}
+
+/**
+ * Wire the registry as a consumer of `persistent_expired` on a runtime
+ * event-system context. After this call, any `persistent_expired` event that
+ * flows through `emit(..., ctx)` — including those emitted by PersistentTrait
+ * via a TraitContext bound to this ctx — records an invalidation.
+ *
+ * @returns the registry (the passed one, or the process-wide default).
+ */
+export function attachStateInvalidationConsumer(
+  ctx: EventSystemContext,
+  registry: StateInvalidationRegistry = defaultStateInvalidationRegistry,
+): StateInvalidationRegistry {
+  onEvent('persistent_expired', makeStateInvalidationHandler(registry), ctx);
+  return registry;
+}


### PR DESCRIPTION
## Summary
Closes Pattern-E capability gap (board task_1779744793932_tfmr). `PersistentTrait.onUpdate` emitted `persistent_expired` on TTL expiry but **nothing subscribed** — the event went into the void, so no reader could learn a persisted value was cleared and needed refetch.

- `StateInvalidationRegistry` + `attachStateInvalidationConsumer` subscribe the registry to `persistent_expired` via the runtime event-system (Stage-4 local listeners). Pure-core, no I/O.
- Default consumer activated in the `HoloScriptRuntime` constructor; readers query `runtime.stateInvalidations` (`wasInvalidated` / `consume`).
- L15 characterization snapshot updated: fresh runtime now ships one default handler by design (eventHandlerCount 0->1); locked no-op property for unlistened emits preserved.

## Test plan
- [x] `state-invalidation.test.ts` 7/7 on a clean origin/main worktree, incl. real PersistentTrait->event-system->registry chain
- [x] Failing-if-broken: expired key IS observed; live key is NOT (no false positive)
- [x] Mutation-verified non-tautological: disabling registration fails the two decisive tests
- [ ] CI build + full suite

Commit 4c19c1867.
