### PR TITLE
feat(studio): Founder Console Inbox tile on /quest-proof (slice B UI, F.085)

### DIFF
--- a/packages/studio/src/app/api/quest-proof/inbox/parse.ts
+++ b/packages/studio/src/app/api/quest-proof/inbox/parse.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure parsing for the Founder Console Inbox (slice B). No Next/runtime imports
+ * so it is unit-testable standalone. route.ts consumes this.
+ *
+ * Agents push via scripts/push-to-founder-console.mjs → a team-feed entry of
+ * kind:"intelligence" whose JSON content carries `founderInbox: true`. This
+ * module turns raw feed entries into inbox items, rejecting anything that isn't
+ * a real founder-push with a usable http(s) url + label (never render junk to
+ * the founder).
+ */
+
+const ARTIFACT_KINDS = new Set(['proof', 'preview', 'action', 'artifact', 'world', 'report']);
+
+export interface FounderInboxItem {
+  id: string;
+  label: string;
+  url: string;
+  kind: string;
+  taskId: string | null;
+  pushedBy: string;
+  ts: string;
+}
+
+interface RawFeedItem {
+  id?: string;
+  feedId?: string;
+  content?: unknown;
+  createdAt?: string;
+  ts?: string;
+}
+
+export function parseFounderInboxEntries(feedItems: unknown, limit = 25): FounderInboxItem[] {
+  const arr = Array.isArray(feedItems) ? feedItems : [];
+  const out: FounderInboxItem[] = [];
+  for (const raw of arr as RawFeedItem[]) {
+    if (!raw || typeof raw !== 'object') continue;
+    let parsed: Record<string, unknown> | null;
+    try {
+      parsed =
+        typeof raw.content === 'string'
+          ? (JSON.parse(raw.content) as Record<string, unknown>)
+          : (raw.content as Record<string, unknown>);
+    } catch {
+      continue;
+    }
+    if (!parsed || parsed.founderInbox !== true) continue;
+    const url = typeof parsed.url === 'string' ? parsed.url : '';
+    const label = typeof parsed.label === 'string' ? parsed.label.trim() : '';
+    if (!/^https?:\/\//i.test(url) || !label) continue;
+    const kind = typeof parsed.kind === 'string' && ARTIFACT_KINDS.has(parsed.kind) ? parsed.kind : 'artifact';
+    const ts = (typeof parsed.ts === 'string' && parsed.ts) || raw.ts || raw.createdAt || new Date(0).toISOString();
+    out.push({
+      id: String(raw.id ?? raw.feedId ?? `${url}:${ts}`),
+      label: label.slice(0, 200),
+      url,
+      kind,
+      taskId: typeof parsed.taskId === 'string' ? parsed.taskId : null,
+      pushedBy: typeof parsed.pushedBy === 'string' ? parsed.pushedBy : 'agent',
+      ts,
+    });
+  }
+  out.sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  return out.slice(0, Math.max(1, limit));
+}
+
+export function extractFeedArray(body: unknown): unknown {
+  if (Array.isArray(body)) return body;
+  const b = body as Record<string, unknown> | null;
+  return b?.feed ?? b?.items ?? b?.entries ?? [];
+}

--- a/packages/studio/src/app/api/quest-proof/inbox/parseFounderInboxEntries.test.ts
+++ b/packages/studio/src/app/api/quest-proof/inbox/parseFounderInboxEntries.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseFounderInboxEntries } from './parse';
+
+const push = (over: Record<string, unknown> = {}) => ({
+  id: (over.id as string) ?? 'f1',
+  content: JSON.stringify({
+    founderInbox: true,
+    v: 1,
+    url: 'https://holoscript.studio/quest-proof',
+    label: 'world ready',
+    kind: 'action',
+    taskId: null,
+    pushedBy: 'claude',
+    ts: '2026-05-26T20:00:00.000Z',
+    ...over,
+  }),
+});
+
+describe('parseFounderInboxEntries', () => {
+  it('extracts a founderInbox feed entry into an inbox item', () => {
+    const items = parseFounderInboxEntries([push()]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      label: 'world ready',
+      url: 'https://holoscript.studio/quest-proof',
+      kind: 'action',
+    });
+  });
+
+  it('FAILING-IF-BROKEN: a non-founderInbox feed entry is NOT rendered', () => {
+    const ordinary = { id: 'x', content: JSON.stringify({ kind: 'intelligence', content: 'board report' }) };
+    expect(parseFounderInboxEntries([ordinary])).toHaveLength(0);
+  });
+
+  it('rejects junk: non-URL or empty label never reaches the founder', () => {
+    expect(parseFounderInboxEntries([push({ url: 'not-a-url' })])).toHaveLength(0);
+    expect(parseFounderInboxEntries([push({ label: '   ' })])).toHaveLength(0);
+  });
+
+  it('newest-first and capped by limit', () => {
+    const items = parseFounderInboxEntries(
+      [
+        push({ id: 'a', label: 'older', ts: '2026-05-26T10:00:00.000Z' }),
+        push({ id: 'b', label: 'newer', ts: '2026-05-26T22:00:00.000Z' }),
+      ],
+      1,
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe('newer');
+  });
+
+  it('tolerates malformed content + non-array input', () => {
+    expect(parseFounderInboxEntries([{ id: 'bad', content: '{not json' }])).toHaveLength(0);
+    expect(parseFounderInboxEntries(null)).toHaveLength(0);
+  });
+});

--- a/packages/studio/src/app/api/quest-proof/inbox/route.ts
+++ b/packages/studio/src/app/api/quest-proof/inbox/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { parseFounderInboxEntries, extractFeedArray } from './parse';
+
+export const runtime = 'nodejs';
+
+/**
+ * Founder Console Inbox (slice B, UI half) — server route.
+ *
+ * Reads the deployed team feed and returns founder-push items (see parse.ts)
+ * so the QuestProofPanel renders them with an Open button. Server-side because
+ * the feed read needs the orchestrator key. Closes F.085: the founder never
+ * types a URL into his Quest — agents push, this surfaces it.
+ */
+
+const BASE =
+  process.env.HOLOMESH_API_URL ?? process.env.MCP_SERVER_URL ?? 'https://mcp.holoscript.net';
+const KEY = process.env.HOLOMESH_API_KEY ?? process.env.HOLOMESH_KEY ?? '';
+const TEAM_ID = process.env.HOLOMESH_TEAM_ID ?? '';
+
+export async function GET(req: NextRequest) {
+  const limit = Math.min(Number(req.nextUrl.searchParams.get('limit')) || 25, 100);
+  if (!TEAM_ID) {
+    return NextResponse.json({ ok: false, items: [], error: 'HOLOMESH_TEAM_ID not configured' });
+  }
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (KEY) {
+      headers['Authorization'] = `Bearer ${KEY}`;
+      headers['x-mcp-api-key'] = KEY;
+    }
+    const res = await fetch(`${BASE}/api/holomesh/team/${TEAM_ID}/feed?limit=${Math.min(limit * 4, 200)}`, {
+      headers,
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, items: [], error: `feed upstream ${res.status}` });
+    }
+    const body = await res.json().catch(() => null);
+    const items = parseFounderInboxEntries(extractFeedArray(body), limit);
+    return NextResponse.json({ ok: true, items });
+  } catch (err) {
+    return NextResponse.json({
+      ok: false,
+      items: [],
+      error: err instanceof Error ? err.message : 'feed fetch failed',
+    });
+  }
+}

--- a/packages/studio/src/components/quest/QuestProofPanel.tsx
+++ b/packages/studio/src/components/quest/QuestProofPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FounderInboxItem } from '../../app/api/quest-proof/inbox/parse';
 
 import { questProofGuardReason } from '../../lib/questProofGuards';
 
@@ -239,6 +240,8 @@ export function QuestProofPanel() {
   const [filingTask, setFilingTask] = useState(false);
   const apiPath = useMemo(() => `${pathPrefix()}/api/quest-proof`, []);
   const taskApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/task`, []);
+  const inboxApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/inbox`, []);
+  const [inbox, setInbox] = useState<FounderInboxItem[]>([]);
 
   useEffect(() => {
     setRunId(currentRunId());
@@ -266,6 +269,23 @@ export function QuestProofPanel() {
     const interval = window.setInterval(() => void loadReceipts(), 6000);
     return () => window.clearInterval(interval);
   }, [clientReady, loadReceipts]);
+
+  // Founder Inbox (F.085): poll artifacts agents PUSHED to the founder so he
+  // opens them here instead of typing URLs into his Quest.
+  const loadInbox = useCallback(async () => {
+    if (!clientReady) return;
+    const res = await fetchWithTimeout(`${inboxApiPath}?limit=25`, {}, 2500);
+    if (!res?.ok) return;
+    const data = (await res.json()) as { ok?: boolean; items?: FounderInboxItem[] };
+    setInbox(Array.isArray(data.items) ? data.items : []);
+  }, [inboxApiPath, clientReady]);
+
+  useEffect(() => {
+    if (!clientReady) return undefined;
+    void loadInbox();
+    const interval = window.setInterval(() => void loadInbox(), 6000);
+    return () => window.clearInterval(interval);
+  }, [clientReady, loadInbox]);
 
   const counts = useMemo(() => countReceipts(receipts), [receipts]);
   const latestByPage = useMemo(() => latestReceiptsByPage(receipts), [receipts]);
@@ -441,6 +461,80 @@ export function QuestProofPanel() {
             />
           </label>
         </div>
+
+        {inbox.length > 0 && (
+          <div
+            data-testid="founder-inbox"
+            style={{
+              marginTop: 16,
+              border: '1px solid #1f6feb',
+              borderRadius: 10,
+              background: '#0d1b3a',
+              padding: 14,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+              <span style={{ color: '#60a5fa', fontWeight: 900, fontSize: 16 }}>Inbox</span>
+              <span
+                style={{
+                  background: '#1f6feb',
+                  color: '#fff',
+                  borderRadius: 999,
+                  padding: '2px 10px',
+                  fontSize: 13,
+                  fontWeight: 800,
+                }}
+              >
+                {inbox.length}
+              </span>
+              <span style={{ color: '#94a3b8', fontSize: 12 }}>pushed to you by agents</span>
+            </div>
+            <div style={{ display: 'grid', gap: 10 }}>
+              {inbox.map((item) => (
+                <a
+                  key={item.id}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setLastOpened(item.url)}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 12,
+                    minHeight: 64,
+                    padding: '12px 16px',
+                    borderRadius: 8,
+                    border: '1px solid #334155',
+                    background: '#111827',
+                    color: '#e5e7eb',
+                    textDecoration: 'none',
+                  }}
+                >
+                  <span style={{ display: 'grid', gap: 2 }}>
+                    <span style={{ fontWeight: 800, fontSize: 16 }}>{item.label}</span>
+                    <span style={{ color: '#64748b', fontSize: 12 }}>
+                      {item.kind} · {item.pushedBy}
+                    </span>
+                  </span>
+                  <span
+                    style={{
+                      background: '#1f6feb',
+                      color: '#fff',
+                      borderRadius: 8,
+                      padding: '10px 18px',
+                      fontWeight: 900,
+                      fontSize: 15,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Open
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div
           style={{


### PR DESCRIPTION
## Summary
Completes slice B: the artifact->headset push so the founder never types a URL into his Quest.

- Agents push via `scripts/push-to-founder-console.mjs` (shipped to ai-ecosystem main, verified live) -> team-feed entry with `founderInbox` marker.
- New `GET /api/quest-proof/inbox` reads the deployed team feed server-side and returns inbox items (pure parser in `parse.ts`).
- `QuestProofPanel` renders an Inbox tile above the fold (per IA spec) with Open buttons, 6s poll.

## Test plan
- [x] `parseFounderInboxEntries` 5/5 (vitest) incl. failing-if-broken (non-founderInbox entry must NOT render) + junk rejection
- [x] changed files typecheck clean
- [ ] visual render verifies on Railway deploy of studio

Closes slice B (task_1779825718767_g2zj). 🤖 Generated with Claude Code