### PR TITLE
feat(studio): NextActions anticipatory tap-chips on the Console (N1+N2, D.066)

### DIFF
--- a/packages/studio/src/app/api/quest-proof/next-actions/nextActions.test.ts
+++ b/packages/studio/src/app/api/quest-proof/next-actions/nextActions.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { buildProposedActions, inferActionType, chipLabel } from './nextActions';
+
+const task = (over: Record<string, unknown> = {}) => ({
+  id: (over.id as string) ?? 't1',
+  title: (over.title as string) ?? '[wire][studio] Add the inbox tile',
+  status: (over.status as string) ?? 'open',
+  priority: (over.priority as number) ?? 2,
+});
+
+describe('buildProposedActions', () => {
+  it('maps an open board task to a proposed action with a clean label', () => {
+    const a = buildProposedActions([task()]);
+    expect(a).toHaveLength(1);
+    expect(a[0]).toMatchObject({ status: 'proposed', taskId: 't1', actionType: 'code', reversible: true });
+    expect(a[0].label).toBe('Add the inbox tile'); // bracket prefixes stripped
+  });
+
+  it('FAILING-IF-BROKEN: only OPEN tasks are anticipatable (claimed/blocked/done excluded)', () => {
+    const tasks = [task({ id: 'o', status: 'open' }), task({ id: 'c', status: 'claimed' }), task({ id: 'd', status: 'done' })];
+    const a = buildProposedActions(tasks, 10);
+    expect(a.map((x) => x.taskId)).toEqual(['o']);
+  });
+
+  it('SAFETY: irreversible / spend / rental tasks are flagged NOT one-tap (reversible=false)', () => {
+    expect(buildProposedActions([task({ title: 'Deploy studio to Railway' })])[0].reversible).toBe(false);
+    expect(buildProposedActions([task({ title: 'Rent a vast.ai GPU for the fine-tune' })])[0].reversible).toBe(false);
+    expect(buildProposedActions([task({ title: 'force-push main' })])[0].reversible).toBe(false);
+  });
+
+  it('ranks by priority ascending and caps by limit', () => {
+    const a = buildProposedActions(
+      [task({ id: 'lo', priority: 3, title: 'low' }), task({ id: 'hi', priority: 1, title: 'high' })],
+      1,
+    );
+    expect(a).toHaveLength(1);
+    expect(a[0].taskId).toBe('hi');
+  });
+
+  it('infers actionType from the title', () => {
+    expect(inferActionType('build a hololand world')).toBe('spatial');
+    expect(inferActionType('rent gpu fleet')).toBe('service_rental');
+    expect(inferActionType('fix the parser')).toBe('code');
+  });
+
+  it('tolerates junk + non-array input', () => {
+    expect(buildProposedActions(null)).toHaveLength(0);
+    expect(buildProposedActions([{ status: 'open' }])).toHaveLength(0); // no id/title
+    expect(chipLabel('[a][b] x')).toBe('x');
+  });
+});

--- a/packages/studio/src/app/api/quest-proof/next-actions/nextActions.ts
+++ b/packages/studio/src/app/api/quest-proof/next-actions/nextActions.ts
@@ -1,0 +1,96 @@
+/**
+ * NextActions aggregator (Anticipatory Actions, D.066 — pure half).
+ *
+ * The founder doctrine: anticipate the next 3-4 moves so the human TAPS instead
+ * of typing. This maps the deployed team board's top open tasks into lightweight
+ * `ProposedAction` views the Console renders as approve-on-tap chips.
+ *
+ * Honesty note: this is NOT a full agi-action-manifest (that schema requires
+ * provenance/verification/safety/replay/closeout we can't truthfully fill from a
+ * board task). It carries the schema's KEY discriminators — actionType, status,
+ * intent, and a `reversible` flag for the one-tap safety gate (D.044). The full
+ * manifest is materialized at approve-time (N3). No facade.
+ *
+ * No Next/runtime imports — unit-testable standalone.
+ */
+
+export type ProposedActionType = 'code' | 'spatial' | 'service_rental' | 'mobility_coordination';
+
+export interface ProposedAction {
+  id: string;
+  /** Short verb-y label for the tap chip. */
+  label: string;
+  /** The human-readable intent (the task title / what tapping will do). */
+  intent: string;
+  actionType: ProposedActionType;
+  status: 'proposed';
+  /** Source board task id (artifact ref the approve step will act on). */
+  taskId: string;
+  priority: number;
+  /**
+   * One-tap eligible iff reversible. Irreversible / spend / custody actions show
+   * the chip but route through the approval/safety-envelope gate (D.044) —
+   * never one-tap-auto.
+   */
+  reversible: boolean;
+  /** Where tapping the chip takes the founder (server-attached; needs TEAM_ID). */
+  href?: string;
+}
+
+interface BoardTaskLike {
+  id?: string;
+  title?: string;
+  status?: string;
+  priority?: number;
+}
+
+const IRREVERSIBLE_RE =
+  /\b(deploy|force[- ]?push|reset|delete|retire|spend|pay|purchase|rent|mainnet|treasury|trezor|custody|sign|broadcast|merge to main|publish (on-chain|edition))\b/i;
+
+const SPATIAL_RE = /\b(world|scene|hololand|zone|render|hologram|quilt|avatar|reconstruct|holomap)\b/i;
+const RENTAL_RE = /\b(rent|rental|gpu|fleet|vast|provision|compute)\b/i;
+const MOBILITY_RE = /\b(mobility|trip|route|navigate|door-to-door)\b/i;
+
+export function inferActionType(title: string): ProposedActionType {
+  if (RENTAL_RE.test(title)) return 'service_rental';
+  if (MOBILITY_RE.test(title)) return 'mobility_coordination';
+  if (SPATIAL_RE.test(title)) return 'spatial';
+  return 'code';
+}
+
+/** Strip the bracketed [scope][tag] prefixes board titles carry, for a clean chip label. */
+export function chipLabel(title: string): string {
+  const stripped = title.replace(/^(\s*\[[^\]]*\])+\s*/, '').trim();
+  return (stripped || title).slice(0, 80);
+}
+
+/**
+ * Map open board tasks → ranked ProposedAction views (newest-highest-priority
+ * first), capped. Only `open` tasks are anticipatable next moves.
+ */
+export function buildProposedActions(tasks: unknown, limit = 4): ProposedAction[] {
+  const arr = Array.isArray(tasks) ? (tasks as BoardTaskLike[]) : [];
+  const out: ProposedAction[] = [];
+  for (const t of arr) {
+    if (!t || typeof t !== 'object') continue;
+    if (t.status !== 'open') continue; // claimed/blocked/done are not "next" taps
+    const title = typeof t.title === 'string' ? t.title : '';
+    const id = typeof t.id === 'string' ? t.id : '';
+    if (!title || !id) continue;
+    const actionType = inferActionType(title);
+    const reversible = !IRREVERSIBLE_RE.test(title) && actionType !== 'service_rental' && actionType !== 'mobility_coordination';
+    out.push({
+      id: `proposed:${id}`,
+      label: chipLabel(title),
+      intent: title.slice(0, 200),
+      actionType,
+      status: 'proposed',
+      taskId: id,
+      priority: typeof t.priority === 'number' ? t.priority : 5,
+      reversible,
+    });
+  }
+  // priority ascending (1 = most urgent) is the rank
+  out.sort((a, b) => a.priority - b.priority);
+  return out.slice(0, Math.max(1, limit));
+}

--- a/packages/studio/src/app/api/quest-proof/next-actions/route.ts
+++ b/packages/studio/src/app/api/quest-proof/next-actions/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildProposedActions } from './nextActions';
+
+export const runtime = 'nodejs';
+
+/**
+ * NextActions (Anticipatory Actions, D.066 — server half).
+ *
+ * Reads the deployed team board and returns the top proposed next actions the
+ * Console renders as approve-on-tap chips, so the founder taps instead of types.
+ * Server-side because the board read needs the orchestrator key.
+ */
+
+const BASE =
+  process.env.HOLOMESH_API_URL ?? process.env.MCP_SERVER_URL ?? 'https://mcp.holoscript.net';
+const KEY = process.env.HOLOMESH_API_KEY ?? process.env.HOLOMESH_KEY ?? '';
+const TEAM_ID = process.env.HOLOMESH_TEAM_ID ?? '';
+
+export async function GET(req: NextRequest) {
+  const limit = Math.min(Number(req.nextUrl.searchParams.get('limit')) || 4, 12);
+  if (!TEAM_ID) {
+    return NextResponse.json({ ok: false, actions: [], error: 'HOLOMESH_TEAM_ID not configured' });
+  }
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (KEY) {
+      headers['Authorization'] = `Bearer ${KEY}`;
+      headers['x-mcp-api-key'] = KEY;
+    }
+    const res = await fetch(`${BASE}/api/holomesh/team/${TEAM_ID}/board?limit=200`, {
+      headers,
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, actions: [], error: `board upstream ${res.status}` });
+    }
+    const body = await res.json().catch(() => null);
+    const tasks = Array.isArray(body?.tasks) ? body.tasks : [];
+    // Tapping a chip takes the founder to act on the task (the board). The
+    // one-tap auto-execute loop is a follow-on (needs Studio's signed-write path).
+    const boardHref = `/holomesh/team/${TEAM_ID}/board`;
+    const actions = buildProposedActions(tasks, limit).map((a) => ({ ...a, href: boardHref }));
+    return NextResponse.json({ ok: true, actions });
+  } catch (err) {
+    return NextResponse.json({
+      ok: false,
+      actions: [],
+      error: err instanceof Error ? err.message : 'board fetch failed',
+    });
+  }
+}

--- a/packages/studio/src/components/quest/QuestProofPanel.tsx
+++ b/packages/studio/src/components/quest/QuestProofPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FounderInboxItem } from '../../app/api/quest-proof/inbox/parse';
+import type { ProposedAction } from '../../app/api/quest-proof/next-actions/nextActions';
 
 import { questProofGuardReason } from '../../lib/questProofGuards';
 
@@ -242,6 +243,8 @@ export function QuestProofPanel() {
   const taskApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/task`, []);
   const inboxApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/inbox`, []);
   const [inbox, setInbox] = useState<FounderInboxItem[]>([]);
+  const nextActionsApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/next-actions`, []);
+  const [nextActions, setNextActions] = useState<ProposedAction[]>([]);
 
   useEffect(() => {
     setRunId(currentRunId());
@@ -286,6 +289,23 @@ export function QuestProofPanel() {
     const interval = window.setInterval(() => void loadInbox(), 6000);
     return () => window.clearInterval(interval);
   }, [clientReady, loadInbox]);
+
+  // NextActions (D.066): the anticipated next 3-4 moves as tap chips, so the
+  // founder taps instead of types. Sourced from the team board (server route).
+  const loadNextActions = useCallback(async () => {
+    if (!clientReady) return;
+    const res = await fetchWithTimeout(`${nextActionsApiPath}?limit=4`, {}, 2500);
+    if (!res?.ok) return;
+    const data = (await res.json()) as { ok?: boolean; actions?: ProposedAction[] };
+    setNextActions(Array.isArray(data.actions) ? data.actions : []);
+  }, [nextActionsApiPath, clientReady]);
+
+  useEffect(() => {
+    if (!clientReady) return undefined;
+    void loadNextActions();
+    const interval = window.setInterval(() => void loadNextActions(), 6000);
+    return () => window.clearInterval(interval);
+  }, [clientReady, loadNextActions]);
 
   const counts = useMemo(() => countReceipts(receipts), [receipts]);
   const latestByPage = useMemo(() => latestReceiptsByPage(receipts), [receipts]);
@@ -529,6 +549,60 @@ export function QuestProofPanel() {
                     }}
                   >
                     Open
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {nextActions.length > 0 && (
+          <div
+            data-testid="next-actions"
+            style={{
+              marginTop: 16,
+              border: '1px solid #16a34a',
+              borderRadius: 10,
+              background: '#0c1f14',
+              padding: 14,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+              <span style={{ color: '#4ade80', fontWeight: 900, fontSize: 16 }}>Next</span>
+              <span style={{ color: '#94a3b8', fontSize: 12 }}>anticipated moves — tap to act</span>
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+              {nextActions.map((a) => (
+                <a
+                  key={a.id}
+                  href={a.href ?? '#'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setLastOpened(a.taskId)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    minHeight: 64,
+                    padding: '12px 18px',
+                    borderRadius: 8,
+                    border: `1px solid ${a.reversible ? '#16a34a' : '#b45309'}`,
+                    background: a.reversible ? '#111827' : '#1c1207',
+                    color: '#e5e7eb',
+                    textDecoration: 'none',
+                    fontWeight: 800,
+                    fontSize: 15,
+                  }}
+                >
+                  <span>{a.label}</span>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 700,
+                      color: a.reversible ? '#4ade80' : '#f59e0b',
+                    }}
+                  >
+                    {a.reversible ? 'tap to do' : 'review'}
                   </span>
                 </a>
               ))}


### PR DESCRIPTION
## Summary
Anticipatory Actions (D.066): anticipate the next 3-4 moves so the founder TAPS instead of typing. Stacks on #214 (inbox) — base is the #214 branch so this diff is just N1+N2.

- **N1** `next-actions/nextActions.ts` (pure) + `route.ts`: maps OPEN board tasks -> ranked `ProposedAction` views (status:proposed) with a `reversible` flag for the one-tap safety gate (D.044). Honest: not a full agi-action-manifest (materializes at approve-time, N3).
- **N2** QuestProofPanel: 'Next - anticipated moves, tap to act' chip strip; reversible=green 'tap to do', irreversible=amber 'review' (gated).

## Test plan
- [x] nextActions 6/6 (vitest) incl. failing-if-broken (only OPEN anticipatable) + SAFETY (deploy/spend/force-push flagged non-one-tap)
- [x] changed files typecheck clean
- [ ] visual render on Railway deploy
- [ ] one-tap auto-execute loop (N3) — needs Studio signed-write path

Merge order: #214 -> main, then this. 🤖 Generated with Claude Code