### PR TITLE
feat(holomesh): founder-approval route — N3 signed-write keystone

### DIFF
--- a/packages/mcp-server/src/holomesh/routes/__tests__/founder-approval-policy.test.ts
+++ b/packages/mcp-server/src/holomesh/routes/__tests__/founder-approval-policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveApprovalReversibility,
+  inferApprovalActionType,
+} from '../founder-approval-policy';
+
+describe('founder-approval-policy — deriveApprovalReversibility', () => {
+  it('admits plain code intents as reversible one-tap', () => {
+    const r = deriveApprovalReversibility('Add a unit test for the parser');
+    expect(r.reversible).toBe(true);
+    expect(r.actionType).toBe('code');
+  });
+
+  it('admits spatial intents as reversible', () => {
+    const r = deriveApprovalReversibility('Render the scene preview for the demo zone');
+    expect(r.reversible).toBe(true);
+    expect(r.actionType).toBe('spatial');
+  });
+
+  it.each([
+    ['Deploy studio to production', 'deploy'],
+    ['Force-push the rebased branch', 'force-push'],
+    ['Spend treasury on the audit', 'spend/treasury'],
+    ['Sign and broadcast the on-chain anchor', 'sign/broadcast'],
+    ['Merge to main after review', 'merge to main'],
+    ['Delete the stale world', 'delete'],
+  ])('blocks irreversible intent: %s', (title) => {
+    const r = deriveApprovalReversibility(title);
+    expect(r.reversible).toBe(false);
+    expect(r.reason).toMatch(/irreversible|review/i);
+  });
+
+  it('blocks service_rental even without an irreversible verb', () => {
+    const r = deriveApprovalReversibility('Provision a GPU fleet for the benchmark');
+    expect(r.actionType).toBe('service_rental');
+    expect(r.reversible).toBe(false);
+  });
+
+  it('blocks mobility_coordination', () => {
+    const r = deriveApprovalReversibility('Coordinate the door-to-door mobility trip');
+    expect(r.actionType).toBe('mobility_coordination');
+    expect(r.reversible).toBe(false);
+  });
+
+  it('inferApprovalActionType prioritizes rental over spatial', () => {
+    // "render" (spatial) + "gpu" (rental) → rental wins (spend gate is stricter)
+    expect(inferApprovalActionType('render on a rented gpu')).toBe('service_rental');
+  });
+});

--- a/packages/mcp-server/src/holomesh/routes/__tests__/team-routes.test.ts
+++ b/packages/mcp-server/src/holomesh/routes/__tests__/team-routes.test.ts
@@ -791,3 +791,113 @@ describe('Board Routes — Team Message Read State', () => {
     expect(stored?.readBy).toEqual([PARENT_ID]);
   });
 });
+
+describe('Board Routes — Founder Approval (N3 signed-write path)', () => {
+  const TEAM = 'team_test_mobile';
+  const APPROVAL_URL = `/api/holomesh/team/${TEAM}/founder-approval`;
+
+  function seedTask(id: string, title: string): void {
+    const team = teamStore.get(TEAM)!;
+    team.taskBoard = [
+      ...(team.taskBoard || []),
+      {
+        id,
+        title,
+        description: title,
+        status: 'open',
+        priority: 1,
+        createdAt: new Date().toISOString(),
+      } as any,
+    ];
+    persistTeamStore();
+  }
+
+  it('records a reversible approval and round-trips it Bearer-authed', async () => {
+    seedTask('task_rev_1', 'Add a unit test for the holoscript parser');
+
+    const post = await callBoard('POST', APPROVAL_URL, { taskId: 'task_rev_1' }, PARENT_KEY);
+    expect(post._status).toBe(201);
+    expect(post._body.success).toBe(true);
+    expect(post._body.approval.status).toBe('approved');
+    expect(post._body.approval.actionType).toBe('code');
+    expect(post._body.approval.taskId).toBe('task_rev_1');
+    expect(post._body.approval.approvedByAgentId).toBe(PARENT_ID);
+
+    // Round-trip: the consume-loop poll sees it. (No query string here — the
+    // shared callBoard helper passes the raw path as `pathname`, and the route
+    // regex is anchored; production strips the query via new URL().pathname
+    // before dispatch, so the ?status= filter is exercised live, not in-harness.)
+    const get = await callBoard('GET', APPROVAL_URL, undefined, PARENT_KEY);
+    expect(get._status).toBe(200);
+    expect(get._body.count).toBe(1);
+    expect(get._body.approvals[0].id).toBe(post._body.approval.id);
+    expect(get._body.approvals[0].status).toBe('approved');
+
+    // Persisted on the team object (rides taskBoard's persistence path).
+    expect(teamStore.get(TEAM)?.founderApprovals?.[0].id).toBe(post._body.approval.id);
+  });
+
+  it('403s an irreversible (deploy) intent — stays on explicit review', async () => {
+    seedTask('task_irrev_1', 'Deploy studio to production and merge to main');
+
+    const post = await callBoard('POST', APPROVAL_URL, { taskId: 'task_irrev_1' }, PARENT_KEY);
+    expect(post._status).toBe(403);
+    expect(post._body.requiresExplicitReview).toBe(true);
+    expect(post._body.error).toMatch(/not one-tap/i);
+
+    // Nothing recorded.
+    expect(teamStore.get(TEAM)?.founderApprovals ?? []).toHaveLength(0);
+  });
+
+  it('403s a service_rental intent (spend gate, D.044)', async () => {
+    seedTask('task_rent_1', 'Provision a GPU fleet on vast.ai for the benchmark');
+
+    const post = await callBoard('POST', APPROVAL_URL, { taskId: 'task_rent_1' }, PARENT_KEY);
+    expect(post._status).toBe(403);
+    expect(post._body.actionType).toBe('service_rental');
+    expect(post._body.requiresExplicitReview).toBe(true);
+  });
+
+  it('rejects a missing taskId with 400', async () => {
+    const post = await callBoard('POST', APPROVAL_URL, {}, PARENT_KEY);
+    expect(post._status).toBe(400);
+  });
+
+  it('lets a signing agent PATCH the lifecycle approved → executing → executed', async () => {
+    seedTask('task_rev_2', 'Refactor the trait composition helper');
+    const post = await callBoard('POST', APPROVAL_URL, { taskId: 'task_rev_2' }, PARENT_KEY);
+    expect(post._status).toBe(201);
+    const approvalId = post._body.approval.id;
+
+    const exec = await callBoard(
+      'PATCH',
+      `${APPROVAL_URL}/${approvalId}`,
+      { status: 'executing' },
+      PARENT_KEY
+    );
+    expect(exec._status).toBe(200);
+    expect(exec._body.approval.status).toBe('executing');
+    expect(exec._body.approval.claimedByAgentId).toBe(PARENT_ID);
+
+    const done = await callBoard(
+      'PATCH',
+      `${APPROVAL_URL}/${approvalId}`,
+      { status: 'executed', resultRef: 'feed_abc123' },
+      PARENT_KEY
+    );
+    expect(done._status).toBe(200);
+    expect(done._body.approval.status).toBe('executed');
+    expect(done._body.approval.resultRef).toBe('feed_abc123');
+    expect(done._body.approval.executedAt).toBeTruthy();
+  });
+
+  it('PATCH 404s an unknown approval id', async () => {
+    const res = await callBoard(
+      'PATCH',
+      `${APPROVAL_URL}/approval_nope`,
+      { status: 'executed' },
+      PARENT_KEY
+    );
+    expect(res._status).toBe(404);
+  });
+});

--- a/packages/mcp-server/src/holomesh/routes/board-routes.ts
+++ b/packages/mcp-server/src/holomesh/routes/board-routes.ts
@@ -65,10 +65,12 @@ import type {
   TeamFleetSnapshotHealth,
   TeamFleetSnapshotPayload,
   TeamFleetSnapshotRecord,
+  FounderApprovalRecord,
 } from '../types';
 import { getClient } from '../orchestrator-client';
 import { mergeTeamKnowledgeWithOrchestrator } from '../entry-lookup';
 import { getBoardModeFields } from '../mode-provenance';
+import { deriveApprovalReversibility } from './founder-approval-policy';
 
 const MAX_FEED_QUERY = 100;
 
@@ -1616,6 +1618,160 @@ export async function handleBoardRoutes(
     persistTeamStore();
 
     json(res, 201, { success: true, item });
+    return true;
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Founder-approval (N3 signed-write path).
+  //
+  // Separates APPROVAL (low-stakes founder intent, recorded here, Bearer-authed)
+  // from EXECUTION (the real mutation, performed later by a signing agent with
+  // its own x402 envelope). This route is intentionally NOT x402-gated: it
+  // records intent and mutates nothing privileged. The custody line (F.002) is
+  // never crossed — no signing key lives in the browser. The one-tap safety
+  // gate (D.044) is enforced server-side: only REVERSIBLE intents are admitted;
+  // irreversible / spend / custody intents are 403'd and stay on explicit review.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // POST /api/holomesh/team/:id/founder-approval — record a one-tap approval
+  if (
+    pathname.match(/^\/api\/holomesh\/team\/[^/]+\/founder-approval$/) &&
+    method === 'POST'
+  ) {
+    const access = await requireTeamAccessFresh(req, res, url, 'board:write');
+    if (!access) return true;
+    const { teamId, caller } = access;
+    const team = teamStore.get(teamId)!;
+
+    const body = (await parseJsonBody(req)) as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object') {
+      json(res, 400, { error: 'JSON object body required' });
+      return true;
+    }
+    const taskId = typeof body.taskId === 'string' ? body.taskId.trim() : '';
+    if (!taskId) {
+      json(res, 400, { error: 'taskId is required' });
+      return true;
+    }
+
+    // Re-derive reversibility from the SERVER's copy of the task title — never
+    // trust a client-sent reversible flag. Fall back to the client intent string
+    // only when the task is not on the board (e.g. just-closed); still gated.
+    const task = (team.taskBoard || []).find((t) => t.id === taskId);
+    const clientIntent = typeof body.intent === 'string' ? body.intent.trim() : '';
+    const intent = (task?.title || clientIntent || '').slice(0, 400);
+    if (!intent) {
+      json(res, 400, { error: 'no task found for taskId and no intent provided' });
+      return true;
+    }
+
+    const { actionType, reversible, reason } = deriveApprovalReversibility(intent);
+    if (!reversible) {
+      // 403 — irreversible/spend/custody intents are not one-tap. The Console
+      // keeps these on the explicit navigate-to-review path.
+      json(res, 403, {
+        error: 'intent is not one-tap eligible',
+        reason,
+        actionType,
+        taskId,
+        requiresExplicitReview: true,
+      });
+      return true;
+    }
+
+    const record: FounderApprovalRecord = {
+      id: `approval_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      taskId,
+      intent,
+      actionType,
+      approvedByAgentId: caller.id,
+      approvedByName: caller.name,
+      status: 'approved',
+      createdAt: new Date().toISOString(),
+    };
+    const list = team.founderApprovals || [];
+    list.push(record);
+    const cap = 200;
+    team.founderApprovals = list.length > cap ? list.slice(-cap) : list;
+    persistTeamStore();
+
+    broadcastToTeam(teamId, {
+      type: 'founder:approval' as any,
+      agent: caller.name,
+      data: { id: record.id, taskId, actionType, intent: intent.slice(0, 120) },
+    });
+
+    json(res, 201, { success: true, approval: record });
+    return true;
+  }
+
+  // GET /api/holomesh/team/:id/founder-approval[?status=approved] — poll approvals
+  // The signing agent's consume loop polls this with ?status=approved.
+  if (
+    pathname.match(/^\/api\/holomesh\/team\/[^/]+\/founder-approval$/) &&
+    method === 'GET'
+  ) {
+    const access = await requireTeamAccessFresh(req, res, url, 'board:read');
+    if (!access) return true;
+    const { teamId } = access;
+    const team = teamStore.get(teamId)!;
+    const statusFilter = new URL(url, 'http://localhost').searchParams.get('status');
+    let approvals = team.founderApprovals || [];
+    if (statusFilter) {
+      approvals = approvals.filter((a) => a.status === statusFilter);
+    }
+    json(res, 200, { success: true, approvals, count: approvals.length });
+    return true;
+  }
+
+  // PATCH /api/holomesh/team/:id/founder-approval/:approvalId — signing agent
+  // updates lifecycle: approved → executing → executed | failed (+ resultRef).
+  if (
+    pathname.match(/^\/api\/holomesh\/team\/[^/]+\/founder-approval\/[^/]+$/) &&
+    method === 'PATCH'
+  ) {
+    const access = await requireTeamAccessFresh(req, res, url, 'board:write');
+    if (!access) return true;
+    const { teamId, caller } = access;
+    const team = teamStore.get(teamId)!;
+    const approvalId = pathname.split('/').pop() as string;
+
+    const body = (await parseJsonBody(req)) as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object') {
+      json(res, 400, { error: 'JSON object body required' });
+      return true;
+    }
+    const nextStatus = body.status as FounderApprovalRecord['status'] | undefined;
+    const allowed: FounderApprovalRecord['status'][] = ['executing', 'executed', 'failed'];
+    if (!nextStatus || !allowed.includes(nextStatus)) {
+      json(res, 400, { error: `status must be one of ${allowed.join(', ')}` });
+      return true;
+    }
+    const record = (team.founderApprovals || []).find((a) => a.id === approvalId);
+    if (!record) {
+      json(res, 404, { error: 'approval not found' });
+      return true;
+    }
+    record.status = nextStatus;
+    if (nextStatus === 'executing') {
+      record.claimedByAgentId = caller.id;
+      record.claimedByName = caller.name;
+    }
+    if (nextStatus === 'executed' || nextStatus === 'failed') {
+      record.executedAt = new Date().toISOString();
+    }
+    if (typeof body.resultRef === 'string') {
+      record.resultRef = body.resultRef.slice(0, 500);
+    }
+    persistTeamStore();
+
+    broadcastToTeam(teamId, {
+      type: 'founder:approval:update' as any,
+      agent: caller.name,
+      data: { id: record.id, status: record.status, resultRef: record.resultRef },
+    });
+
+    json(res, 200, { success: true, approval: record });
     return true;
   }
 

--- a/packages/mcp-server/src/holomesh/routes/founder-approval-policy.ts
+++ b/packages/mcp-server/src/holomesh/routes/founder-approval-policy.ts
@@ -1,0 +1,72 @@
+/**
+ * Founder-approval reversibility policy (N3 signed-write path — pure half).
+ *
+ * The founder-approval route records low-stakes INTENT only; a signing agent
+ * later executes the real mutation with its own x402 envelope. The one-tap
+ * safety gate (D.044): only REVERSIBLE intents may be auto-approved. Irreversible
+ * / spend / custody intents are 403'd by the route and stay on the explicit
+ * navigate-to-review path.
+ *
+ * This derivation is the SERVER-SIDE authority. It MUST mirror the Studio
+ * `nextActions.ts` `reversible` flag
+ * (packages/studio/src/app/api/quest-proof/next-actions/nextActions.ts) so the
+ * chip a founder sees as "tap to do" is exactly what the server admits. Never
+ * trust a client-sent reversible flag — re-derive from the task title here.
+ *
+ * No http/runtime imports — unit-testable standalone.
+ */
+
+export type FounderApprovalActionType =
+  | 'code'
+  | 'spatial'
+  | 'service_rental'
+  | 'mobility_coordination';
+
+// ── MIRRORS packages/studio/src/app/api/quest-proof/next-actions/nextActions.ts ──
+// Keep these three regexes byte-identical to the Studio half. If you change one,
+// change both — divergence means the founder taps a chip the server then rejects.
+const IRREVERSIBLE_RE =
+  /\b(deploy|force[- ]?push|reset|delete|retire|spend|pay|purchase|rent|mainnet|treasury|trezor|custody|sign|broadcast|merge to main|publish (on-chain|edition))\b/i;
+const SPATIAL_RE =
+  /\b(world|scene|hololand|zone|render|hologram|quilt|avatar|reconstruct|holomap)\b/i;
+const RENTAL_RE = /\b(rent|rental|gpu|fleet|vast|provision|compute)\b/i;
+const MOBILITY_RE = /\b(mobility|trip|route|navigate|door-to-door)\b/i;
+
+export function inferApprovalActionType(text: string): FounderApprovalActionType {
+  if (RENTAL_RE.test(text)) return 'service_rental';
+  if (MOBILITY_RE.test(text)) return 'mobility_coordination';
+  if (SPATIAL_RE.test(text)) return 'spatial';
+  return 'code';
+}
+
+export interface ApprovalReversibility {
+  actionType: FounderApprovalActionType;
+  /** One-tap eligible iff true. False intents must route through explicit review. */
+  reversible: boolean;
+  /** Human-readable reason the route returns on a 403. */
+  reason: string;
+}
+
+/**
+ * Re-derive reversibility for a founder-approval intent from its text (the board
+ * task title, or the intent string if no task is found). The route 403s when
+ * `reversible` is false.
+ */
+export function deriveApprovalReversibility(text: string): ApprovalReversibility {
+  const actionType = inferApprovalActionType(text);
+  if (IRREVERSIBLE_RE.test(text)) {
+    return {
+      actionType,
+      reversible: false,
+      reason: 'intent matches an irreversible / spend / custody verb (D.044) — explicit review required',
+    };
+  }
+  if (actionType === 'service_rental' || actionType === 'mobility_coordination') {
+    return {
+      actionType,
+      reversible: false,
+      reason: `actionType "${actionType}" is never one-tap auto-approved (D.044) — explicit review required`,
+    };
+  }
+  return { actionType, reversible: true, reason: 'reversible' };
+}

--- a/packages/mcp-server/src/holomesh/types.ts
+++ b/packages/mcp-server/src/holomesh/types.ts
@@ -505,6 +505,16 @@ export interface Team {
   /** Latest locally-published GPU/Vast fleet snapshot for deployed Studio and agents. */
   fleetSnapshot?: TeamFleetSnapshotRecord;
 
+  /**
+   * Founder one-tap approvals (N3 signed-write path). Records the low-stakes
+   * INTENT a founder tapped on the Console; a signing agent consumes
+   * status:'approved', materializes the full agi-action-manifest, executes with
+   * ITS own x402 envelope, and PATCHes the record to 'executed'. Stored directly
+   * on the team object so it persists/reloads through the same path as taskBoard
+   * (no side map needed — see state.ts persistTeamStore).
+   */
+  founderApprovals?: FounderApprovalRecord[];
+
   // Bounty data (V7 Expansion)
   bounties?: BountyManager;
   submissions?: StoredBountySubmission[];
@@ -554,6 +564,40 @@ export interface Team {
   };
   treasuryWallet?: string;
   treasuryBalance?: number;
+}
+
+/**
+ * A founder one-tap approval (N3 signed-write path). The Console records this
+ * when a founder taps a REVERSIBLE next-action chip. It mutates nothing
+ * privileged — it is an intent ticket a signing agent consumes. The signing
+ * agent re-validates, materializes the agi-action-manifest, executes with its
+ * own x402 signature, and PATCHes status → 'executed' + a resultRef.
+ */
+export interface FounderApprovalRecord {
+  id: string;
+  /** Source board task this intent acts on. */
+  taskId: string;
+  /** Human-readable intent (the task title / what tapping does). */
+  intent: string;
+  /** Re-derived server-side; only reversible intents are ever recorded. */
+  actionType: 'code' | 'spatial' | 'service_rental' | 'mobility_coordination';
+  /** Identity that tapped approve (from Bearer auth, never client-supplied). */
+  approvedByAgentId: string;
+  approvedByName: string;
+  /**
+   * approved   → recorded, awaiting a signing agent
+   * executing  → a signing agent claimed it and is materializing/signing
+   * executed   → the signed mutation landed; resultRef points to the receipt
+   * failed     → execution failed; resultRef carries the reason
+   */
+  status: 'approved' | 'executing' | 'executed' | 'failed';
+  createdAt: string;
+  /** Set by the signing agent when it claims the record. */
+  claimedByAgentId?: string;
+  claimedByName?: string;
+  executedAt?: string;
+  /** Receipt hash / inbox feed id / failure reason, depending on status. */
+  resultRef?: string;
 }
 
 export type TeamFleetSnapshotHealthStatus = 'missing' | 'ok' | 'degraded' | 'stale' | 'down';


### PR DESCRIPTION
## What

The keystone of the N3 signed-write path (D.066). Makes a founder tap on the deployed Console drive a real team-state change without a signing key ever touching the browser (F.002 custody).

Blocker solved: deployed Studio has only a Bearer key and cannot produce the x402 envelope team mutations require. This route separates approval (low-stakes founder intent, Bearer-authed) from execution (the signed mutation, done later by a signing agent).

## Routes (board-routes.ts)
- POST /api/holomesh/team/:id/founder-approval — Bearer-authed, NOT x402-gated. Re-derives reversibility server-side and 403s irreversible/spend/custody intents (D.044). Reversible-only.
- GET .../founder-approval?status=approved — signing-agent consume-loop poll.
- PATCH .../founder-approval/:id — lifecycle approved to executing to executed|failed (+resultRef).

## Design
- founder-approval-policy.ts — pure, unit-tested reversibility derivation mirroring Studio nextActions.ts byte-for-byte. Server is the authority.
- FounderApprovalRecord stored on the Team object → persists like taskBoard (no side map).

## Tests — 42/42 green
6 route round-trip tests (Bearer record+read-back, 403 deploy, 403 service_rental, 400, PATCH lifecycle, 404) + 11 policy tests + 25 existing team-routes tests unbroken.

Done-when (N3): approval route round-trips Bearer-authed and 403s an irreversible intent — both asserted and passing.

## Follow-ons
- Studio next-actions POST proxy + panel one-tap (stacks on #215).
- Signing-agent consume loop.

Generated with Claude Code