### PR TITLE
feat(studio): one-tap founder approval on the Console (N3 Front)

### DIFF
--- a/packages/studio/src/app/api/quest-proof/next-actions/route.test.ts
+++ b/packages/studio/src/app/api/quest-proof/next-actions/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * POST /api/quest-proof/next-actions — the N3 one-tap approval proxy.
+ *
+ * The route reads HOLOMESH_* env at module load, so each test sets env then
+ * dynamic-imports a fresh module (vi.resetModules). global fetch is mocked to
+ * stand in for the team-API `founder-approval` route.
+ */
+describe('next-actions POST — founder one-tap approval proxy', () => {
+  const ORIG_TEAM = process.env.HOLOMESH_TEAM_ID;
+  const ORIG_KEY = process.env.HOLOMESH_API_KEY;
+
+  beforeEach(() => {
+    process.env.HOLOMESH_TEAM_ID = 'team_test';
+    process.env.HOLOMESH_API_KEY = 'test-key';
+    vi.resetModules();
+  });
+  afterEach(() => {
+    process.env.HOLOMESH_TEAM_ID = ORIG_TEAM;
+    process.env.HOLOMESH_API_KEY = ORIG_KEY;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function loadPOST() {
+    const mod = await import('./route');
+    return mod.POST;
+  }
+  function req(body: unknown) {
+    return new Request('http://localhost/api/quest-proof/next-actions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }) as never;
+  }
+
+  it('400s a missing taskId', async () => {
+    const POST = await loadPOST();
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards taskId to the founder-approval route and returns ok on upstream 201', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ success: true, approval: { id: 'approval_1', status: 'approved' } }),
+        { status: 201 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const POST = await loadPOST();
+    const res = await POST(req({ taskId: 'task_1', intent: 'Add a test' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.approval.id).toBe('approval_1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/founder-approval');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body).taskId).toBe('task_1');
+  });
+
+  it('surfaces requiresExplicitReview when the team-API 403s an irreversible intent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'not one-tap eligible', reason: 'irreversible' }), {
+        status: 403,
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const POST = await loadPOST();
+    const res = await POST(req({ taskId: 'task_deploy' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.ok).toBe(false);
+    expect(json.requiresExplicitReview).toBe(true);
+  });
+
+  it('502s when the team-API errors', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'boom' }), { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const POST = await loadPOST();
+    const res = await POST(req({ taskId: 'task_1' }));
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/studio/src/app/api/quest-proof/next-actions/route.ts
+++ b/packages/studio/src/app/api/quest-proof/next-actions/route.ts
@@ -36,8 +36,9 @@ export async function GET(req: NextRequest) {
     }
     const body = await res.json().catch(() => null);
     const tasks = Array.isArray(body?.tasks) ? body.tasks : [];
-    // Tapping a chip takes the founder to act on the task (the board). The
-    // one-tap auto-execute loop is a follow-on (needs Studio's signed-write path).
+    // Tapping a REVERSIBLE chip records a founder-approval via POST below (the
+    // one-tap signed-write path, N3). Irreversible chips carry an href so the
+    // panel routes them to explicit review instead (D.044).
     const boardHref = `/holomesh/team/${TEAM_ID}/board`;
     const actions = buildProposedActions(tasks, limit).map((a) => ({ ...a, href: boardHref }));
     return NextResponse.json({ ok: true, actions });
@@ -47,5 +48,75 @@ export async function GET(req: NextRequest) {
       actions: [],
       error: err instanceof Error ? err.message : 'board fetch failed',
     });
+  }
+}
+
+/**
+ * POST — one-tap founder approval (N3 signed-write path).
+ *
+ * The panel calls this when a founder taps a REVERSIBLE chip. It proxies the
+ * tap (server-side Bearer key) to the team-API `founder-approval` route, which
+ * records low-stakes intent a signing agent later executes. No signing key ever
+ * reaches the browser (F.002 custody). The team-API re-derives reversibility
+ * server-side and 403s irreversible/spend/custody intents (D.044) — Studio does
+ * NOT pre-trust the client; it forwards taskId and lets the authority decide.
+ */
+export async function POST(req: NextRequest) {
+  if (!TEAM_ID) {
+    return NextResponse.json(
+      { ok: false, error: 'HOLOMESH_TEAM_ID not configured' },
+      { status: 503 }
+    );
+  }
+  let payload: { taskId?: unknown; intent?: unknown } | null = null;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'JSON body required' }, { status: 400 });
+  }
+  const taskId = typeof payload?.taskId === 'string' ? payload.taskId.trim() : '';
+  if (!taskId) {
+    return NextResponse.json({ ok: false, error: 'taskId is required' }, { status: 400 });
+  }
+  const intent = typeof payload?.intent === 'string' ? payload.intent.slice(0, 400) : undefined;
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (KEY) {
+      headers['Authorization'] = `Bearer ${KEY}`;
+      headers['x-mcp-api-key'] = KEY;
+    }
+    const res = await fetch(`${BASE}/api/holomesh/team/${TEAM_ID}/founder-approval`, {
+      method: 'POST',
+      headers,
+      cache: 'no-store',
+      body: JSON.stringify({ taskId, intent }),
+    });
+    const upstream = await res.json().catch(() => null);
+    if (res.status === 403) {
+      // Irreversible intent — surface the review requirement so the panel keeps
+      // it on the explicit navigate-to-review path instead of optimistically
+      // removing the chip.
+      return NextResponse.json(
+        {
+          ok: false,
+          requiresExplicitReview: true,
+          reason: upstream?.reason ?? 'intent is not one-tap eligible',
+        },
+        { status: 403 }
+      );
+    }
+    if (!res.ok) {
+      return NextResponse.json(
+        { ok: false, error: upstream?.error ?? `approval upstream ${res.status}` },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json({ ok: true, approval: upstream?.approval ?? null });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : 'approval failed' },
+      { status: 502 }
+    );
   }
 }

--- a/packages/studio/src/components/quest/QuestProofPanel.tsx
+++ b/packages/studio/src/components/quest/QuestProofPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import type { FounderInboxItem } from '../../app/api/quest-proof/inbox/parse';
 import type { ProposedAction } from '../../app/api/quest-proof/next-actions/nextActions';
 
@@ -245,6 +245,10 @@ export function QuestProofPanel() {
   const [inbox, setInbox] = useState<FounderInboxItem[]>([]);
   const nextActionsApiPath = useMemo(() => `${pathPrefix()}/api/quest-proof/next-actions`, []);
   const [nextActions, setNextActions] = useState<ProposedAction[]>([]);
+  // N3 one-tap: chips mid-approval, and chips that just landed an approval (so
+  // the tile shows "approved ✓" for a beat before the next poll drops them).
+  const [approvingId, setApprovingId] = useState<string | null>(null);
+  const [approvedIds, setApprovedIds] = useState<Record<string, true>>({});
 
   useEffect(() => {
     setRunId(currentRunId());
@@ -306,6 +310,44 @@ export function QuestProofPanel() {
     const interval = window.setInterval(() => void loadNextActions(), 6000);
     return () => window.clearInterval(interval);
   }, [clientReady, loadNextActions]);
+
+  // N3 one-tap: tapping a REVERSIBLE chip records a founder-approval (server
+  // proxies the Bearer call to the team-API; a signing agent executes it). On
+  // success the chip is optimistically marked approved and removed on next poll.
+  // If the server 403s (intent turned out irreversible), fall back to navigate.
+  const approveAction = useCallback(
+    async (a: ProposedAction) => {
+      if (approvingId) return;
+      setApprovingId(a.id);
+      try {
+        const res = await fetchWithTimeout(
+          nextActionsApiPath,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ taskId: a.taskId, intent: a.intent }),
+          },
+          4000
+        );
+        if (res?.ok) {
+          setApprovedIds((prev) => ({ ...prev, [a.id]: true }));
+          setLastOpened(a.taskId);
+          // Drop it from the list shortly after the "approved" flash.
+          window.setTimeout(() => {
+            setNextActions((prev) => prev.filter((x) => x.id !== a.id));
+          }, 1200);
+        } else if (res?.status === 403 && a.href) {
+          // Server says explicit review required — navigate instead.
+          window.open(a.href, '_blank', 'noopener,noreferrer');
+        }
+      } catch {
+        /* transient — the 6s poll will re-offer the chip */
+      } finally {
+        setApprovingId(null);
+      }
+    },
+    [approvingId, nextActionsApiPath]
+  );
 
   const counts = useMemo(() => countReceipts(receipts), [receipts]);
   const latestByPage = useMemo(() => latestReceiptsByPage(receipts), [receipts]);
@@ -572,40 +614,64 @@ export function QuestProofPanel() {
               <span style={{ color: '#94a3b8', fontSize: 12 }}>anticipated moves — tap to act</span>
             </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-              {nextActions.map((a) => (
-                <a
-                  key={a.id}
-                  href={a.href ?? '#'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => setLastOpened(a.taskId)}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 10,
-                    minHeight: 64,
-                    padding: '12px 18px',
-                    borderRadius: 8,
-                    border: `1px solid ${a.reversible ? '#16a34a' : '#b45309'}`,
-                    background: a.reversible ? '#111827' : '#1c1207',
-                    color: '#e5e7eb',
-                    textDecoration: 'none',
-                    fontWeight: 800,
-                    fontSize: 15,
-                  }}
-                >
-                  <span>{a.label}</span>
-                  <span
-                    style={{
-                      fontSize: 11,
-                      fontWeight: 700,
-                      color: a.reversible ? '#4ade80' : '#f59e0b',
-                    }}
+              {nextActions.map((a) => {
+                const approved = approvedIds[a.id] === true;
+                const busy = approvingId === a.id;
+                const chipStyle: CSSProperties = {
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  minHeight: 64,
+                  padding: '12px 18px',
+                  borderRadius: 8,
+                  border: `1px solid ${a.reversible ? '#16a34a' : '#b45309'}`,
+                  background: approved ? '#0f2a1a' : a.reversible ? '#111827' : '#1c1207',
+                  color: '#e5e7eb',
+                  textDecoration: 'none',
+                  fontWeight: 800,
+                  fontSize: 15,
+                  cursor: 'pointer',
+                  font: 'inherit',
+                  textAlign: 'left',
+                  opacity: busy ? 0.6 : 1,
+                };
+                const badge = (text: string, color: string) => (
+                  <span style={{ fontSize: 11, fontWeight: 700, color }}>{text}</span>
+                );
+                // Reversible → one-tap approve button (records intent, no navigation,
+                // no signing key in the browser). Irreversible → navigate to review.
+                if (a.reversible) {
+                  return (
+                    <button
+                      key={a.id}
+                      type="button"
+                      disabled={busy || approved}
+                      onClick={() => void approveAction(a)}
+                      style={chipStyle}
+                    >
+                      <span>{a.label}</span>
+                      {approved
+                        ? badge('approved ✓', '#4ade80')
+                        : busy
+                          ? badge('approving…', '#94a3b8')
+                          : badge('tap to do', '#4ade80')}
+                    </button>
+                  );
+                }
+                return (
+                  <a
+                    key={a.id}
+                    href={a.href ?? '#'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setLastOpened(a.taskId)}
+                    style={chipStyle}
                   >
-                    {a.reversible ? 'tap to do' : 'review'}
-                  </span>
-                </a>
-              ))}
+                    <span>{a.label}</span>
+                    {badge('review', '#f59e0b')}
+                  </a>
+                );
+              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
## What

The Front half of the N3 signed-write path (D.066). Turns the NextActions chip from tap-to-navigate into tap-and-it-is-recorded-for-execution. Stacks on #215 (NextActions) and pairs with #217 (the team-API founder-approval route).

## Changes
- next-actions/route.ts gains POST: proxies the tap (server-side Bearer key) to the team-API founder-approval route. No signing key ever reaches the browser (F.002 custody). A 403 (irreversible) is surfaced as requiresExplicitReview so the panel keeps those on navigate-to-review (D.044); upstream 5xx -> 502.
- QuestProofPanel: REVERSIBLE chips render as one-tap approve buttons (optimistic approving -> approved, dropped on next 6s poll). Irreversible chips stay navigate-to-review links. >=64px tap targets preserved.

## Tests — 10/10 green
4 POST-proxy tests (400 missing taskId; forwards taskId + ok on upstream 201; surfaces requiresExplicitReview on 403; 502 on upstream error) + 6 existing nextActions tests. Studio typecheck clean on touched files (remaining tsc noise is pre-existing unbuilt-workspace @holoscript/core resolution).

## Stack / deploy order
#214 (Inbox) -> #215 (NextActions) -> this, plus #217 (founder-approval route) on the team-API. Live verification pending deploy of the stack.

Generated with Claude Code