### PR TITLE
feat(studio): console design system — interaction-first primitives (D.066)

### DIFF
--- a/packages/studio/src/components/console/ActionChip.tsx
+++ b/packages/studio/src/components/console/ActionChip.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { tokens } from './tokens';
+import { TapTarget } from './primitives';
+
+/**
+ * <ActionChip> — generalizes the NextActions tap-chip (#215) + its N3 one-tap
+ * approve behavior (#218). Two variants:
+ *  - reversible: a one-tap APPROVE button (green) — records intent, no nav.
+ *  - gated (irreversible): a navigate-to-review link (amber) — D.044.
+ * The variant drives color + affordance; never a hover state.
+ */
+export interface ActionChipProps {
+  label: string;
+  reversible: boolean;
+  /** Reversible chips: the one-tap action. */
+  onApprove?: () => void;
+  /** Gated chips: where review happens. */
+  href?: string;
+  /** Gated chips: fired when the founder taps through to review. */
+  onReview?: () => void;
+  /** Reversible chip mid-approval / just-approved. */
+  busy?: boolean;
+  approved?: boolean;
+  testId?: string;
+}
+
+export function ActionChip({
+  label,
+  reversible,
+  onApprove,
+  href,
+  onReview,
+  busy,
+  approved,
+  testId,
+}: ActionChipProps) {
+  const accent = reversible ? tokens.color.success : tokens.color.warn;
+  const badgeColor = reversible ? tokens.color.successText : tokens.color.warnText;
+  const surface = approved
+    ? tokens.color.successSurface
+    : reversible
+      ? tokens.color.surface
+      : tokens.color.warnSurface;
+
+  const chipStyle = {
+    border: `1px solid ${accent}`,
+    background: surface,
+    fontSize: tokens.font.chip,
+  };
+  const badgeText = approved ? 'approved ✓' : busy ? 'approving…' : reversible ? 'tap to do' : 'review';
+  const badge = (
+    <span style={{ fontSize: tokens.font.label, fontWeight: tokens.weight.bold, color: approved || !busy ? badgeColor : tokens.color.textDim }}>
+      {badgeText}
+    </span>
+  );
+
+  if (reversible) {
+    return (
+      <TapTarget
+        onTap={onApprove}
+        disabled={busy || approved}
+        ariaLabel={`Approve: ${label}`}
+        testId={testId}
+        style={chipStyle}
+      >
+        <span>{label}</span>
+        {badge}
+      </TapTarget>
+    );
+  }
+  return (
+    <TapTarget
+      href={href ?? '#'}
+      newTab
+      onTap={onReview}
+      ariaLabel={`Review: ${label}`}
+      testId={testId}
+      style={chipStyle}
+    >
+      <span>{label}</span>
+      {badge}
+    </TapTarget>
+  );
+}

--- a/packages/studio/src/components/console/ActionTile.tsx
+++ b/packages/studio/src/components/console/ActionTile.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { tokens } from './tokens';
+import { TapTarget } from './primitives';
+
+/**
+ * <ActionTile> — generalizes the Founder Console Inbox "Open" tile (#214).
+ * A labelled card with a single primary tap action. Quest + mobile legible:
+ * large target, explicit colors, no hover.
+ */
+export interface ActionTileProps {
+  label: string;
+  sublabel?: string;
+  /** Primary action label (default "Open"). */
+  actionLabel?: string;
+  href?: string;
+  onTap?: () => void;
+  testId?: string;
+}
+
+export function ActionTile({
+  label,
+  sublabel,
+  actionLabel = 'Open',
+  href,
+  onTap,
+  testId,
+}: ActionTileProps) {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: tokens.space.md,
+        padding: tokens.space.md,
+        borderRadius: tokens.radius.md,
+        background: tokens.color.surface,
+        border: `1px solid ${tokens.color.border}`,
+        minHeight: tokens.tap.min,
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            color: tokens.color.text,
+            fontSize: tokens.font.tile,
+            fontWeight: tokens.weight.bold,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </div>
+        {sublabel ? (
+          <div style={{ color: tokens.color.textDim, fontSize: tokens.font.label }}>{sublabel}</div>
+        ) : null}
+      </div>
+      <TapTarget
+        href={href}
+        onTap={onTap}
+        newTab={Boolean(href)}
+        ariaLabel={`${actionLabel}: ${label}`}
+        testId={testId ? `${testId}-action` : undefined}
+        style={{
+          background: tokens.color.accent,
+          border: `1px solid ${tokens.color.accent}`,
+          color: '#fff',
+          minWidth: 96,
+          justifyContent: 'center',
+        }}
+      >
+        {actionLabel}
+      </TapTarget>
+    </div>
+  );
+}

--- a/packages/studio/src/components/console/SayOrType.tsx
+++ b/packages/studio/src/components/console/SayOrType.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { tokens } from './tokens';
+import { TapTarget } from './primitives';
+
+/**
+ * <SayOrType> — the Talk + Type-conversational primitives in one bar
+ * (generalizes the Message→Task box). The human SAYS it (voice affordance,
+ * Brittney) or TYPES it conversationally — never a command. There is no command
+ * syntax, no slash, no file path. Submitting hands the free-text intent up; the
+ * agent turns it into action.
+ */
+export interface SayOrTypeProps {
+  placeholder?: string;
+  /** Called with the conversational text when the human submits. */
+  onSubmit: (text: string) => void;
+  /** Called when the human taps the talk affordance (voice capture). */
+  onTalk?: () => void;
+  submitLabel?: string;
+  busy?: boolean;
+  testId?: string;
+}
+
+export function SayOrType({
+  placeholder = 'Say or type what you want…',
+  onSubmit,
+  onTalk,
+  submitLabel = 'Send',
+  busy,
+  testId,
+}: SayOrTypeProps) {
+  const [text, setText] = useState('');
+  const submit = () => {
+    const t = text.trim();
+    if (!t || busy) return;
+    onSubmit(t);
+    setText('');
+  };
+  return (
+    <div
+      data-testid={testId}
+      style={{ display: 'flex', gap: tokens.space.sm, alignItems: 'stretch', flexWrap: 'wrap' }}
+    >
+      {onTalk ? (
+        <TapTarget
+          onTap={onTalk}
+          ariaLabel="Talk"
+          testId={testId ? `${testId}-talk` : undefined}
+          style={{
+            background: tokens.color.surface,
+            border: `1px solid ${tokens.color.accent}`,
+            color: tokens.color.text,
+            minWidth: tokens.tap.min,
+            justifyContent: 'center',
+          }}
+        >
+          🎙 Talk
+        </TapTarget>
+      ) : null}
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit();
+        }}
+        placeholder={placeholder}
+        aria-label="Say or type"
+        data-testid={testId ? `${testId}-input` : undefined}
+        style={{
+          flex: 1,
+          minWidth: 160,
+          minHeight: tokens.tap.min,
+          padding: `${tokens.space.sm}px ${tokens.space.md}px`,
+          borderRadius: tokens.radius.sm,
+          background: tokens.color.bg,
+          color: tokens.color.text,
+          border: `1px solid ${tokens.color.border}`,
+          fontSize: tokens.font.chip,
+        }}
+      />
+      <TapTarget
+        onTap={submit}
+        disabled={busy || text.trim().length === 0}
+        ariaLabel={submitLabel}
+        testId={testId ? `${testId}-send` : undefined}
+        style={{
+          background: tokens.color.success,
+          border: `1px solid ${tokens.color.success}`,
+          color: '#fff',
+          minWidth: 88,
+          justifyContent: 'center',
+        }}
+      >
+        {submitLabel}
+      </TapTarget>
+    </div>
+  );
+}

--- a/packages/studio/src/components/console/StatusStrip.tsx
+++ b/packages/studio/src/components/console/StatusStrip.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { tokens } from './tokens';
+
+/**
+ * <StatusStrip> — a glanceable horizontal row of status counts (OK/WARN/FAIL
+ * and friends). Read-only by default; each cell may carry an onTap to drill in
+ * (Tap primitive). Quest-legible: large text, explicit colors, no hover.
+ */
+export interface StatusCell {
+  label: string;
+  value: number | string;
+  tone?: 'ok' | 'warn' | 'fail' | 'neutral';
+  onTap?: () => void;
+}
+
+const toneColor = {
+  ok: tokens.color.successText,
+  warn: tokens.color.warnText,
+  fail: tokens.color.danger,
+  neutral: tokens.color.textDim,
+} as const;
+
+export interface StatusStripProps {
+  cells: StatusCell[];
+  testId?: string;
+}
+
+export function StatusStrip({ cells, testId }: StatusStripProps) {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: tokens.space.sm,
+        alignItems: 'stretch',
+      }}
+    >
+      {cells.map((c, i) => {
+        const color = toneColor[c.tone ?? 'neutral'];
+        const interactive = typeof c.onTap === 'function';
+        const inner = (
+          <>
+            <span style={{ color, fontSize: tokens.font.title, fontWeight: tokens.weight.heavy }}>
+              {c.value}
+            </span>
+            <span style={{ color: tokens.color.textDim, fontSize: tokens.font.label }}>{c.label}</span>
+          </>
+        );
+        const cellStyle = {
+          display: 'flex',
+          flexDirection: 'column' as const,
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+          // Interactive cells meet the tap minimum; static cells are glance-only.
+          minHeight: interactive ? tokens.tap.min : 44,
+          minWidth: tokens.tap.min,
+          padding: `${tokens.space.sm}px ${tokens.space.md}px`,
+          borderRadius: tokens.radius.sm,
+          background: tokens.color.surface,
+          border: `1px solid ${tokens.color.border}`,
+        };
+        if (interactive) {
+          return (
+            <button
+              key={`${c.label}-${i}`}
+              type="button"
+              onClick={c.onTap}
+              data-tap-min="64"
+              aria-label={`${c.label}: ${c.value}`}
+              style={{ ...cellStyle, cursor: 'pointer', font: 'inherit' }}
+            >
+              {inner}
+            </button>
+          );
+        }
+        return (
+          <div key={`${c.label}-${i}`} style={cellStyle}>
+            {inner}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/studio/src/components/console/__tests__/console-primitives.test.tsx
+++ b/packages/studio/src/components/console/__tests__/console-primitives.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+/**
+ * Console design-system contract (D.066): every interactive target is >=64px
+ * and nothing depends on hover. Failing-if-broken: a component under 64px, or
+ * any hover-only affordance in the module source, fails this suite.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, cleanup, screen } from '@testing-library/react';
+import { tokens } from '../tokens';
+import { TapTarget } from '../primitives';
+import { ActionTile } from '../ActionTile';
+import { ActionChip } from '../ActionChip';
+import { StatusStrip } from '../StatusStrip';
+import { SayOrType } from '../SayOrType';
+
+afterEach(cleanup);
+
+/** Inline numeric minHeight renders as "<n>px"; parse and assert >= 64. */
+function tapMinPx(el: HTMLElement): number {
+  return parseInt(el.style.minHeight || '0', 10);
+}
+
+describe('console tokens', () => {
+  it('declares a >=64px tap minimum', () => {
+    expect(tokens.tap.min).toBeGreaterThanOrEqual(64);
+  });
+});
+
+describe('every interactive primitive is >=64px tap size', () => {
+  it('TapTarget (Tap/Click)', () => {
+    render(
+      <TapTarget onTap={() => {}} testId="tt">
+        Go
+      </TapTarget>
+    );
+    expect(tapMinPx(screen.getByTestId('tt'))).toBeGreaterThanOrEqual(64);
+  });
+
+  it('ActionTile primary action', () => {
+    render(<ActionTile label="Open the proof" href="https://x.test" testId="tile" />);
+    expect(tapMinPx(screen.getByTestId('tile-action'))).toBeGreaterThanOrEqual(64);
+  });
+
+  it('ActionChip reversible (one-tap approve)', () => {
+    render(<ActionChip label="Add a test" reversible onApprove={() => {}} testId="chip" />);
+    expect(tapMinPx(screen.getByTestId('chip'))).toBeGreaterThanOrEqual(64);
+  });
+
+  it('ActionChip gated (navigate to review)', () => {
+    render(<ActionChip label="Deploy" reversible={false} href="https://x.test" testId="chip2" />);
+    expect(tapMinPx(screen.getByTestId('chip2'))).toBeGreaterThanOrEqual(64);
+  });
+
+  it('StatusStrip interactive cell', () => {
+    render(<StatusStrip cells={[{ label: 'OK', value: 3, tone: 'ok', onTap: () => {} }]} testId="strip" />);
+    const cell = screen.getByLabelText('OK: 3');
+    expect(tapMinPx(cell)).toBeGreaterThanOrEqual(64);
+  });
+
+  it('SayOrType talk, input, and send all meet the minimum', () => {
+    render(<SayOrType onSubmit={() => {}} onTalk={() => {}} testId="say" />);
+    expect(tapMinPx(screen.getByTestId('say-talk'))).toBeGreaterThanOrEqual(64);
+    expect(tapMinPx(screen.getByTestId('say-input'))).toBeGreaterThanOrEqual(64);
+    expect(tapMinPx(screen.getByTestId('say-send'))).toBeGreaterThanOrEqual(64);
+  });
+});
+
+describe('zero hover-dependence (D.066)', () => {
+  it('no console component uses a hover affordance', () => {
+    const dir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+    const files = readdirSync(dir).filter((f) => /\.(ts|tsx)$/.test(f));
+    expect(files.length).toBeGreaterThan(0);
+    const offenders: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(resolve(dir, f), 'utf8');
+      if (/onMouseEnter|onMouseOver|onMouseLeave|:hover/.test(src)) offenders.push(f);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/studio/src/components/console/index.ts
+++ b/packages/studio/src/components/console/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Console design system — the interaction-first primitives every Front surface
+ * inherits (D.066). Tokens + the 5 interaction primitives (Tap/Click via
+ * TapTarget; Swipe/Talk/Type expressed by the components) + the 4 components.
+ *
+ * No command or file primitive exists here — by design.
+ */
+export { tokens, tapTargetStyle } from './tokens';
+export { TapTarget } from './primitives';
+export type { Interaction, TapTargetProps } from './primitives';
+export { ActionTile } from './ActionTile';
+export type { ActionTileProps } from './ActionTile';
+export { ActionChip } from './ActionChip';
+export type { ActionChipProps } from './ActionChip';
+export { StatusStrip } from './StatusStrip';
+export type { StatusStripProps, StatusCell } from './StatusStrip';
+export { SayOrType } from './SayOrType';
+export type { SayOrTypeProps } from './SayOrType';

--- a/packages/studio/src/components/console/primitives.tsx
+++ b/packages/studio/src/components/console/primitives.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+import { tapTargetStyle } from './tokens';
+
+/**
+ * The interaction primitives (D.066). Humans act in exactly five ways —
+ * Tap, Swipe, Click, Talk, Type-conversational — and NO other. There is no
+ * command or file primitive by design. `TapTarget` is the shared foundation
+ * for Tap (touch/Quest-ray) and Click (desktop): a >=64px, hover-free target
+ * rendered as a real <button> (onTap) or <a> (href). Swipe/Talk/Type are
+ * expressed by the higher-level components (StatusStrip swipe lists, SayOrType
+ * talk+type bar) that build on this base.
+ */
+
+export type Interaction = 'tap' | 'swipe' | 'click' | 'talk' | 'type';
+
+export interface TapTargetProps {
+  children: ReactNode;
+  /** Tap/click handler. Renders a <button>. Mutually exclusive with href. */
+  onTap?: () => void;
+  /** Navigation target. Renders an <a>. Mutually exclusive with onTap. */
+  href?: string;
+  disabled?: boolean;
+  /** Visual variant — maps to explicit (non-hover) colors. */
+  style?: CSSProperties;
+  ariaLabel?: string;
+  testId?: string;
+  newTab?: boolean;
+}
+
+/**
+ * A single tap/click target. Guarantees the >=64px minimum and never relies on
+ * hover. Use `onTap` for actions, `href` for navigation.
+ */
+export function TapTarget({
+  children,
+  onTap,
+  href,
+  disabled,
+  style,
+  ariaLabel,
+  testId,
+  newTab,
+}: TapTargetProps) {
+  const merged = { ...tapTargetStyle(), ...(style || {}) } as CSSProperties;
+  if (disabled) merged.opacity = 0.6;
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        aria-label={ariaLabel}
+        data-testid={testId}
+        data-tap-min="64"
+        target={newTab ? '_blank' : undefined}
+        rel={newTab ? 'noopener noreferrer' : undefined}
+        onClick={onTap}
+        style={merged}
+      >
+        {children}
+      </a>
+    );
+  }
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      data-tap-min="64"
+      disabled={disabled}
+      onClick={onTap}
+      style={merged}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/studio/src/components/console/tokens.ts
+++ b/packages/studio/src/components/console/tokens.ts
@@ -1,0 +1,70 @@
+/**
+ * Console design tokens — the single source of truth every Front surface
+ * inherits (D.066, interaction-first design system).
+ *
+ * Doctrine: humans tap / swipe / click / talk / conversational-type. There is
+ * NO command or file primitive. Every interactive target is at least
+ * `tap.min` px so it is reachable on a Quest controller ray and a phone thumb,
+ * and nothing depends on hover (Quest + touch have no hover). One source — no
+ * per-screen restyle.
+ */
+
+export const tokens = {
+  color: {
+    bg: '#0b1020',
+    surface: '#111827',
+    surfaceAlt: '#0c1f14',
+    accent: '#1f6feb',
+    success: '#16a34a',
+    successText: '#4ade80',
+    successSurface: '#0f2a1a',
+    warn: '#b45309',
+    warnText: '#f59e0b',
+    warnSurface: '#1c1207',
+    danger: '#ef4444',
+    text: '#e5e7eb',
+    textDim: '#94a3b8',
+    border: '#1f2937',
+  },
+  space: { xs: 6, sm: 10, md: 14, lg: 16, xl: 24 },
+  radius: { sm: 8, md: 10, lg: 14, pill: 999 },
+  /** Minimum interactive target, in px. Quest-ray + phone-thumb legible (D.066). */
+  tap: { min: 64 },
+  font: {
+    label: 11,
+    body: 13,
+    chip: 15,
+    tile: 16,
+    title: 18,
+  },
+  weight: { regular: 500, bold: 800, heavy: 900 },
+} as const;
+
+/**
+ * Base style for any tap/click target. Guarantees the >=64px minimum and an
+ * explicit (non-hover) appearance. Spread this first, then override colors.
+ * Keeping it a function (not a frozen object) lets callers extend without
+ * mutating the shared token source.
+ */
+export function tapTargetStyle(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    minHeight: tokens.tap.min,
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.space.sm,
+    padding: `${tokens.space.md}px ${tokens.space.lg}px`,
+    borderRadius: tokens.radius.sm,
+    background: tokens.color.surface,
+    color: tokens.color.text,
+    border: `1px solid ${tokens.color.border}`,
+    fontSize: tokens.font.chip,
+    fontWeight: tokens.weight.bold,
+    textDecoration: 'none',
+    cursor: 'pointer',
+    // Interaction-first: state is conveyed by explicit color/opacity, never by
+    // a CSS hover rule a Quest controller or touch screen cannot trigger.
+    font: 'inherit',
+    textAlign: 'left',
+    ...overrides,
+  };
+}

--- a/packages/studio/src/components/quest/QuestProofPanel.tsx
+++ b/packages/studio/src/components/quest/QuestProofPanel.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FounderInboxItem } from '../../app/api/quest-proof/inbox/parse';
 import type { ProposedAction } from '../../app/api/quest-proof/next-actions/nextActions';
+import { ActionChip } from '../console';
 
 import { questProofGuardReason } from '../../lib/questProofGuards';
 
@@ -614,64 +615,21 @@ export function QuestProofPanel() {
               <span style={{ color: '#94a3b8', fontSize: 12 }}>anticipated moves — tap to act</span>
             </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-              {nextActions.map((a) => {
-                const approved = approvedIds[a.id] === true;
-                const busy = approvingId === a.id;
-                const chipStyle: CSSProperties = {
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 10,
-                  minHeight: 64,
-                  padding: '12px 18px',
-                  borderRadius: 8,
-                  border: `1px solid ${a.reversible ? '#16a34a' : '#b45309'}`,
-                  background: approved ? '#0f2a1a' : a.reversible ? '#111827' : '#1c1207',
-                  color: '#e5e7eb',
-                  textDecoration: 'none',
-                  fontWeight: 800,
-                  fontSize: 15,
-                  cursor: 'pointer',
-                  font: 'inherit',
-                  textAlign: 'left',
-                  opacity: busy ? 0.6 : 1,
-                };
-                const badge = (text: string, color: string) => (
-                  <span style={{ fontSize: 11, fontWeight: 700, color }}>{text}</span>
-                );
-                // Reversible → one-tap approve button (records intent, no navigation,
-                // no signing key in the browser). Irreversible → navigate to review.
-                if (a.reversible) {
-                  return (
-                    <button
-                      key={a.id}
-                      type="button"
-                      disabled={busy || approved}
-                      onClick={() => void approveAction(a)}
-                      style={chipStyle}
-                    >
-                      <span>{a.label}</span>
-                      {approved
-                        ? badge('approved ✓', '#4ade80')
-                        : busy
-                          ? badge('approving…', '#94a3b8')
-                          : badge('tap to do', '#4ade80')}
-                    </button>
-                  );
-                }
-                return (
-                  <a
-                    key={a.id}
-                    href={a.href ?? '#'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => setLastOpened(a.taskId)}
-                    style={chipStyle}
-                  >
-                    <span>{a.label}</span>
-                    {badge('review', '#f59e0b')}
-                  </a>
-                );
-              })}
+              {/* Rendered from the console design system (D.066) — the Console
+                  consumes <ActionChip>, it does not hand-style chips. */}
+              {nextActions.map((a) => (
+                <ActionChip
+                  key={a.id}
+                  label={a.label}
+                  reversible={a.reversible}
+                  href={a.href}
+                  busy={approvingId === a.id}
+                  approved={approvedIds[a.id] === true}
+                  onApprove={() => void approveAction(a)}
+                  onReview={() => setLastOpened(a.taskId)}
+                  testId={`next-action-${a.taskId}`}
+                />
+              ))}
             </div>
           </div>
         )}


### PR DESCRIPTION
## What

The interaction-first design system every Front surface inherits (D.066). Extracts the shipped Inbox tile (#214) + NextActions chip (#215/#218) into a reusable module under packages/studio/src/components/console/, so surfaces stop hand-styling and consume ONE system. No command or file primitive exists — by design.

## Module
- tokens.ts — spacing, radius, dark palette (#0b1020/#1f6feb/#16a34a), font scale, and the >=64px tap minimum. One source, no per-screen restyle.
- primitives.tsx — TapTarget, the Tap/Click foundation (>=64px, hover-free; real button for onTap, anchor for href). Swipe/Talk/Type expressed by the components.
- ActionTile, ActionChip (reversible one-tap / gated review variants), StatusStrip, SayOrType (talk + conversational-type bar, no command syntax).
- index.ts barrel.

## Adoption (real consumer, not a stub)
QuestProofPanel renders the NextActions chips via <ActionChip> instead of hand-styled inline markup; the #218 one-tap approve + navigate-to-review behavior is preserved.

## Tests — 8/8
Every interactive primitive renders at >=64px tap size, and a source guard fails if any console component introduces a hover affordance (onMouseEnter/Over/Leave or :hover). Studio typecheck clean on touched files.

**Done-when:** console/ exports tokens + 4 components, the Console renders from them, and the test renders each at >=64px with zero hover-dependence (failing-if-broken).

## Stack
#214 (Inbox) -> #215 (NextActions) -> #218 (one-tap) -> this. Pairs with #217 (founder-approval route).

Generated with Claude Code