### PR TITLE
fix(studio): tolerate framework tsc declaration-emit in Docker build (unblock Console Front deploy)

### DIFF
--- a/packages/studio/Dockerfile
+++ b/packages/studio/Dockerfile
@@ -80,7 +80,23 @@ RUN cd packages/llm-provider && npx tsup --no-dts && (npx tsup --dts-only || tru
 # memory-tuned batches, but requests up to 6GB heap which OOMs in Railway's
 # build container. The single-pass tsup proved fine in the prior Dockerfile,
 # so we keep it + add the missing tsc declaration step.
-RUN cd packages/framework && npx tsup --no-dts && npx tsc -p tsconfig.build.json
+#
+# The JS build (`tsup --no-dts`) MUST succeed and fails loudly. The tsc step is
+# DECLARATION-EMIT ONLY and is tolerated as optional (`|| true`) — identical to
+# the dts-only philosophy used for every other package above (lines 56-59).
+# Why tolerate: framework imports `@holoscript/core/traits`, whose generated
+# declaration (`core/dist/traits/index.d.ts`) re-exports the namespaced domain
+# plugins (`export * as RadioAstronomyPlugin from '@holoscript/radio-astronomy-plugin'`
+# …). Those plugins' `types` point at SOURCE (`src/index.ts`), so tsc walks ~189
+# plugin source files — including `.tsx` that import `react` / `three` /
+# `@react-three/fiber`, type deps NOT installed in this slim build's resolution
+# scope → TS2307. This is a cross-package SOURCE error in a transitively-walked
+# plugin, not a framework defect: `noEmitOnError` is unset, so framework's own
+# `dist/*.d.ts` still emit before tsc returns non-zero. Tolerating the exit code
+# lets Studio deploy while framework's declarations land correctly. (The deeper
+# fix — core not statically re-exporting domain-plugin source — is tracked
+# separately; see handoff. This unblocks the Console Front deploy now.)
+RUN cd packages/framework && npx tsup --no-dts && (npx tsc -p tsconfig.build.json || true)
 RUN cd packages/std && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/config && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/absorb-service && npx tsup --no-dts && (npx tsup --dts-only || true)


### PR DESCRIPTION
## Summary
- Studio's last 4 Railway deploys failed; production 404s on `/api/quest-proof/inbox` and `/api/quest-proof/next-actions` (stale deploy).
- PR #221 fixed the first blocker (`@holoscript/llm-provider` build order); that un-gated the **next** latent blocker in the framework Docker build step.
- Root cause (via `tsc --explainFiles`): framework imports `@holoscript/core/traits`, whose generated declaration re-exports namespaced domain plugins (`export * as RadioAstronomyPlugin from '@holoscript/radio-astronomy-plugin'` …). Those plugins' `types` point at SOURCE, so framework's `tsc -p tsconfig.build.json` walks ~189 plugin source files, including `.tsx` importing `react`/`three`/`@react-three/fiber` — type deps not in this slim build's resolution scope → TS2307.
- Fix: tolerate the tsc **declaration-emit** exit code (`|| true`), matching the dts-only philosophy already applied to every other package (Dockerfile lines 56-59). The tsup JS build still fails loudly. `noEmitOnError` is unset, so framework's own `dist/*.d.ts` still emit — verified all 11 subpath declarations land.

This carries the merged Console Front (inbox / next-actions / one-tap / design-system) to production.

The deeper architectural fix — core not statically re-exporting domain-plugin SOURCE (per the "never hardcode domain vocabulary into core" rule) — is left for a separate, higher-blast-radius change.

## Test plan
- [x] Reproduced the exact failing `tsc -p tsconfig.build.json` step locally
- [x] Confirmed all 11 framework subpath `.d.ts` emit despite tsc errors
- [ ] Railway Studio deploy succeeds after merge
- [ ] `/api/quest-proof/inbox` and `/api/quest-proof/next-actions` return 200 post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)