### PR TITLE
fix(studio): build @holoscript/secrets-broker in Docker (next deploy blocker)

### DIFF
--- a/packages/studio/Dockerfile
+++ b/packages/studio/Dockerfile
@@ -105,6 +105,12 @@ RUN cd packages/mesh && npx tsup --no-dts && (npx tsup --dts-only || true)
 # (llm-provider moved earlier — see note above, must build before framework)
 RUN cd packages/marketplace-agentkit && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/security-sandbox && npx tsup --no-dts && (npx tsup --dts-only || true)
+# secrets-broker: studio/src/lib/capability-session.ts imports
+# '@holoscript/secrets-broker' (used by api/connectors/disconnect/route.ts), a
+# workspace:* dep. Without its dist on disk, Studio's `next build` (step 32)
+# fails with "Module not found: Can't resolve '@holoscript/secrets-broker'".
+# Zero workspace deps, so it builds standalone here among the leaf packages.
+RUN cd packages/secrets-broker && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN for plugin in packages/plugins/*/; do [ -f "$plugin/tsconfig.json" ] && (cd "$plugin" && npx tsc --noEmit false --declaration false 2>/dev/null || true); done
 RUN cd packages/r3f-renderer && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/studio-plugin-sdk && npx tsup --no-dts && (npx tsup --dts-only || true)


### PR DESCRIPTION
## Summary
- Follow-on to #223. After the tsc-tolerate fix cleared the framework step, the Studio build reached the final `next build` (32/32) and failed: `Module not found: Can't resolve '@holoscript/secrets-broker'` (from `src/lib/capability-session.ts`, used by `api/connectors/disconnect/route.ts`).
- `@holoscript/secrets-broker` is a `workspace:*` dep of studio but was missing from the Dockerfile's topological build list, so its `dist/` never existed in the builder image → webpack couldn't resolve it. Same whack-a-mole class the Dockerfile header documents (lines 36-43).
- Fix: add a build step for it among the leaf packages (zero workspace deps, builds standalone). Verified all 21 of studio's direct `@holoscript/*` deps are now covered by the Dockerfile build list.

Unblocks the Console Front deploy (`/api/quest-proof/inbox`, `/api/quest-proof/next-actions` currently 404 in prod).

## Test plan
- [x] Confirmed secrets-broker is a studio dep, has a `tsup` build, zero workspace deps
- [x] Cross-checked: all 21 studio `@holoscript/*` direct deps now covered in Dockerfile
- [ ] Railway Studio deploy reaches and passes `next build`
- [ ] `/api/quest-proof/inbox` + `/api/quest-proof/next-actions` return 200 post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)