### PR TITLE
fix(studio): build holoembed + holo-vm in Docker for next-build type-check

### DIFF
--- a/packages/studio/Dockerfile
+++ b/packages/studio/Dockerfile
@@ -111,6 +111,14 @@ RUN cd packages/security-sandbox && npx tsup --no-dts && (npx tsup --dts-only ||
 # fails with "Module not found: Can't resolve '@holoscript/secrets-broker'".
 # Zero workspace deps, so it builds standalone here among the leaf packages.
 RUN cd packages/secrets-broker && npx tsup --no-dts && (npx tsup --dts-only || true)
+# holoembed + holo-vm: Studio's `next build` type-check walks engine SOURCE
+# (tsconfig alias "@holoscript/engine": ["../engine/src"]). engine/src imports
+# both — ConjectureEngine.ts -> @holoscript/holoembed, and engine/src/index.ts +
+# vm/index.ts -> @holoscript/holo-vm. Without their dist on disk the type-check
+# fails "Cannot find module '@holoscript/holoembed'". Deps already built above
+# (holoembed: config + snn-webgpu; holo-vm: core), so they slot in here.
+RUN cd packages/holoembed && npx tsup --no-dts && (npx tsup --dts-only || true)
+RUN cd packages/holo-vm && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN for plugin in packages/plugins/*/; do [ -f "$plugin/tsconfig.json" ] && (cd "$plugin" && npx tsc --noEmit false --declaration false 2>/dev/null || true); done
 RUN cd packages/r3f-renderer && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/studio-plugin-sdk && npx tsup --no-dts && (npx tsup --dts-only || true)


### PR DESCRIPTION
## Summary
- Follow-on to #223/#224. After secrets-broker cleared webpack resolution, Studio `next build` compiled (78s) then failed its TYPE-CHECK: `Cannot find module '@holoscript/holoembed'` from `../engine/src/simulation/ConjectureEngine.ts`.
- Studio's type-check walks engine SOURCE (tsconfig alias `@holoscript/engine: ../engine/src`). engine/src imports two packages absent from the Dockerfile build list: `@holoscript/holoembed` (ConjectureEngine.ts) and `@holoscript/holo-vm` (engine/src/index.ts, vm/index.ts).
- Fix: build both (a full sweep of engine/src `@holoscript/*` imports confirms these are the ONLY unbuilt ones). Deps already built earlier (holoembed: config + snn-webgpu; holo-vm: core).

Unblocks the Console Front deploy (`/api/quest-proof/*` 404 in prod).

## Test plan
- [x] Swept engine/src `@holoscript/*` value imports; confirmed holoembed + holo-vm are the only unbuilt ones
- [ ] Railway Studio deploy passes `next build` type-check
- [ ] `/api/quest-proof/inbox` + `/api/quest-proof/next-actions` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)