### PR TITLE
fix(snn-webgpu): drop vestigial react from tsconfig types (fixes dts emit)

### DIFF
--- a/packages/snn-webgpu/tsconfig.json
+++ b/packages/snn-webgpu/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
     "jsx": "react-jsx",
-    "types": ["@webgpu/types", "react", "node"],
+    "types": ["@webgpu/types", "node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Root cause of the snn-webgpu TS7016 that blocked Studio next-build. PR #226 made the dts emit fail-loud, surfacing TS2688 'Cannot find type definition file for react' — snn-webgpu's tsconfig forced @types/react as a global type-lib but doesn't depend on react. The published entry has zero React (the .tsx components aren't exported from index.ts). Removing it fixes the slim-build dts emit and speeds it 9x (51s→6s). Unblocks Console Front deploy (/api/quest-proof/* 404).