### PR TITLE
fix(core): stop re-exporting domain-plugin source from core/traits

### DIFF
--- a/packages/core/scripts/generate-types.mjs
+++ b/packages/core/scripts/generate-types.mjs
@@ -4504,41 +4504,13 @@ export function webcamGazeToRay(
 ): [number, number, number];
 export const webcamGazeHandler: TraitHandler<WebcamGazeConfig>;
 
-// ── Namespaced domain plugins (mirrors packages/core/src/traits/index.ts) ──
-// Keeps \`import { FilmVFXPlugin } from '@holoscript/core/traits'\` resolving after barrel namespacing.
-export * as FilmVFXPlugin from '@holoscript/plugin-film-vfx';
-export * as AlphaFoldPlugin from '@holoscript/alphafold-plugin';
-export * as BankingFinancePlugin from '@holoscript/plugin-banking-finance';
-export * as CivilEngineeringPlugin from '@holoscript/plugin-civil-engineering';
-export * as CultureKeywordPlugin from '@holoscript/plugin-culture-keyword';
-export * as DomainPluginTemplate from '@holoscript/domain-plugin-template';
-export * as EconomicPrimitivesPlugin from '@holoscript/plugin-economic-primitives';
-export * as EducationLmsPlugin from '@holoscript/plugin-education-lms';
-export * as EmergencyResponsePlugin from '@holoscript/plugin-emergency-response';
-export * as FashionPlugin from '@holoscript/plugin-fashion';
-export * as Film3dVolumetricsPlugin from '@holoscript/plugin-film3d-volumetrics';
-export * as FitnessWellnessPlugin from '@holoscript/plugin-fitness-wellness';
-export * as ForensicsPlugin from '@holoscript/plugin-forensics';
-export * as GeolocationGisPlugin from '@holoscript/plugin-geolocation-gis';
-export * as HardwareInventionPlugin from '@holoscript/plugin-hardware-invention';
-export * as HrWorkforcePlugin from '@holoscript/plugin-hr-workforce';
-export * as InsurancePlugin from '@holoscript/plugin-insurance';
-export * as LegalDocumentPlugin from '@holoscript/plugin-legal-document';
-export * as ManufacturingQcPlugin from '@holoscript/plugin-manufacturing-qc';
-export * as MedicalPlugin from '@holoscript/medical-plugin';
-export * as NeurosciencePlugin from '@holoscript/plugin-neuroscience';
-export * as RadioAstronomyPlugin from '@holoscript/radio-astronomy-plugin';
-export * as RestaurantPlugin from '@holoscript/plugin-restaurant';
-export * as RetailEcommercePlugin from '@holoscript/plugin-retail-ecommerce';
-export * as RoboticsPlugin from '@holoscript/robotics-plugin';
-export * as NarupaPlugin from '@holoscript/narupa-plugin';
-export * as TherapyPlugin from '@holoscript/plugin-therapy';
-export * as ThreatIntelligencePlugin from '@holoscript/plugin-threat-intelligence';
-export * as TraitAuditPlugin from '@holoscript/plugin-trait-audit';
-export * as TravelHospitalityPlugin from '@holoscript/plugin-travel-hospitality';
-export * as UrbanPlanningPlugin from '@holoscript/plugin-urban-planning';
-export * as WineFoodBeveragePlugin from '@holoscript/plugin-wine-food-beverage';
-export * as WisdomGotchaPlugin from '@holoscript/plugin-wisdom-gotcha';
+// ── Domain plugins are NOT re-exported from core ──────────────────────────────
+// Core must not statically depend on domain plugins — plugins are data, not code
+// (CLAUDE.md / NORTH_STAR). Re-exporting them (even type-only) forced every
+// consumer of '@holoscript/core/traits' to resolve each plugin's types, which
+// point at source, dragging ~189 plugin source files (incl. .tsx importing
+// react/three) into slim builds → TS2307 (broke Studio deploy 2026-05-26).
+// Import a plugin directly from its own package, e.g. '@holoscript/radio-astronomy-plugin'.
 
 // ── Quantum-Inspired optimization trait ──────────────────────────────────────
 // (packages/core/src/traits/QuantumInspiredTrait.ts)

--- a/packages/core/src/traits/index.ts
+++ b/packages/core/src/traits/index.ts
@@ -459,41 +459,12 @@ export * from './Native2DTraits';
 // v6 Universal Semantic Platform traits
 export * as V6 from './v6';
 
-// External domain plugins stay type-only here. Runtime namespace re-exports pull
-// plugin packages into the MCP server image even when those plugin builds are not copied.
-export type * as FilmVFXPlugin from '@holoscript/plugin-film-vfx';
-export type * as AlphaFoldPlugin from '@holoscript/alphafold-plugin';
-export type * as BankingFinancePlugin from '@holoscript/plugin-banking-finance';
-export type * as CivilEngineeringPlugin from '@holoscript/plugin-civil-engineering';
-export type * as CultureKeywordPlugin from '@holoscript/plugin-culture-keyword';
-export type * as DomainPluginTemplate from '@holoscript/domain-plugin-template';
-export type * as EconomicPrimitivesPlugin from '@holoscript/plugin-economic-primitives';
-export type * as EducationLmsPlugin from '@holoscript/plugin-education-lms';
-export type * as EmergencyResponsePlugin from '@holoscript/plugin-emergency-response';
-export type * as FashionPlugin from '@holoscript/plugin-fashion';
-export type * as Film3dVolumetricsPlugin from '@holoscript/plugin-film3d-volumetrics';
-export type * as FitnessWellnessPlugin from '@holoscript/plugin-fitness-wellness';
-export type * as ForensicsPlugin from '@holoscript/plugin-forensics';
-export type * as GeolocationGisPlugin from '@holoscript/plugin-geolocation-gis';
-// export * as HardwareInventionPlugin from '@holoscript/plugin-hardware-invention'; // package not found
-export type * as HrWorkforcePlugin from '@holoscript/plugin-hr-workforce';
-export type * as InsurancePlugin from '@holoscript/plugin-insurance';
-export type * as LegalDocumentPlugin from '@holoscript/plugin-legal-document';
-export type * as ManufacturingQcPlugin from '@holoscript/plugin-manufacturing-qc';
-export type * as MedicalPlugin from '@holoscript/medical-plugin';
-export type * as NeurosciencePlugin from '@holoscript/plugin-neuroscience';
-export type * as RadioAstronomyPlugin from '@holoscript/radio-astronomy-plugin';
-export type * as RestaurantPlugin from '@holoscript/plugin-restaurant';
-export type * as RetailEcommercePlugin from '@holoscript/plugin-retail-ecommerce';
-export type * as RoboticsPlugin from '@holoscript/robotics-plugin';
-export type * as NarupaPlugin from '@holoscript/narupa-plugin';
-// export * as TherapyPlugin from '@holoscript/plugin-therapy'; // package not found
-export type * as ThreatIntelligencePlugin from '@holoscript/plugin-threat-intelligence';
-export type * as TraitAuditPlugin from '@holoscript/plugin-trait-audit';
-export type * as TravelHospitalityPlugin from '@holoscript/plugin-travel-hospitality';
-export type * as UrbanPlanningPlugin from '@holoscript/plugin-urban-planning';
-export type * as WineFoodBeveragePlugin from '@holoscript/plugin-wine-food-beverage';
-export type * as WisdomGotchaPlugin from '@holoscript/plugin-wisdom-gotcha';
+// Domain plugins are NOT re-exported from core. Core must not statically depend
+// on domain plugins — plugins are data, not code (CLAUDE.md / NORTH_STAR). Even a
+// type-only re-export forces every consumer of '@holoscript/core/traits' to
+// resolve each plugin's types, which point at source, dragging ~189 plugin source
+// files (incl. .tsx importing react/three) into slim builds → TS2307. Import a
+// plugin directly from its own package, e.g. '@holoscript/radio-astronomy-plugin'.
 
 // ── Pillar-Slice Framework (D.040) ────────────────────────────────────────────
 export type {

--- a/packages/studio/Dockerfile
+++ b/packages/studio/Dockerfile
@@ -81,22 +81,15 @@ RUN cd packages/llm-provider && npx tsup --no-dts && (npx tsup --dts-only || tru
 # build container. The single-pass tsup proved fine in the prior Dockerfile,
 # so we keep it + add the missing tsc declaration step.
 #
-# The JS build (`tsup --no-dts`) MUST succeed and fails loudly. The tsc step is
-# DECLARATION-EMIT ONLY and is tolerated as optional (`|| true`) — identical to
-# the dts-only philosophy used for every other package above (lines 56-59).
-# Why tolerate: framework imports `@holoscript/core/traits`, whose generated
-# declaration (`core/dist/traits/index.d.ts`) re-exports the namespaced domain
-# plugins (`export * as RadioAstronomyPlugin from '@holoscript/radio-astronomy-plugin'`
-# …). Those plugins' `types` point at SOURCE (`src/index.ts`), so tsc walks ~189
-# plugin source files — including `.tsx` that import `react` / `three` /
-# `@react-three/fiber`, type deps NOT installed in this slim build's resolution
-# scope → TS2307. This is a cross-package SOURCE error in a transitively-walked
-# plugin, not a framework defect: `noEmitOnError` is unset, so framework's own
-# `dist/*.d.ts` still emit before tsc returns non-zero. Tolerating the exit code
-# lets Studio deploy while framework's declarations land correctly. (The deeper
-# fix — core not statically re-exporting domain-plugin source — is tracked
-# separately; see handoff. This unblocks the Console Front deploy now.)
-RUN cd packages/framework && npx tsup --no-dts && (npx tsc -p tsconfig.build.json || true)
+# Both the JS build (`tsup --no-dts`) and the tsc declaration emit MUST succeed
+# and fail loudly. The earlier `|| true` tolerance was a workaround for core
+# statically re-exporting the namespaced domain plugins from
+# `@holoscript/core/traits`, which dragged ~189 plugin source files (incl. `.tsx`
+# importing react/three) into framework's program → TS2307 in this slim build.
+# That re-export was removed at the source (core/src/traits/index.ts +
+# scripts/generate-types.mjs); core no longer depends on domain-plugin source, so
+# framework's tsc now type-checks clean here and the tolerance is no longer needed.
+RUN cd packages/framework && npx tsup --no-dts && npx tsc -p tsconfig.build.json
 RUN cd packages/std && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/config && npx tsup --no-dts && (npx tsup --dts-only || true)
 RUN cd packages/absorb-service && npx tsup --no-dts && (npx tsup --dts-only || true)


### PR DESCRIPTION
## Summary
`@holoscript/core/traits` re-exported every namespaced domain plugin (`export * as RadioAstronomyPlugin from '@holoscript/...'`). Plugins set `types`/`main` → `src`, so **any** consumer of `@holoscript/core/traits` (e.g. `framework/src/agents/shared-traits.ts`, which only needs `agentMemoryHandler`) forced `tsc` to transitively walk ~189 plugin **source** files — incl. `.tsx` importing `react`/`three`/`@react-three/fiber`. In the slim Studio Docker build those type deps are out of resolution scope → TS2307, which broke the Studio deploy (2026-05-26) and was worked around with `|| true` in the Dockerfile.

This violates the architecture rule "plugins are data, not code; core must not statically depend on domain plugins" (CLAUDE.md / NORTH_STAR).

## Changes
- **`packages/core/src/traits/index.ts`** — removed the plugin namespace re-export block (replaced with an architecture-rule comment).
- **`packages/core/scripts/generate-types.mjs`** — removed the same block from the hand-crafted `dist/traits/index.d.ts` generator (this is the declaration the Docker build actually emits, line 66).
- **`packages/studio/Dockerfile`** — dropped the `|| true` tolerance on the framework `tsc` step; it now fails loud.

## Why removal (not type-only / dist-retarget)
- **0 consumers** import the plugin namespaces from `core/traits` (verified across `packages/`). They were dead re-exports.
- `export type *` does **not** stop type-walking: tsc still resolves each module's types, which point at source.
- Consumers that need a plugin import it directly from its own package, e.g. `@holoscript/radio-astronomy-plugin`.

## Test plan
- [x] `cd packages/framework && npx tsc -p tsconfig.build.json --explainFiles` against the generator-produced `dist/traits/index.d.ts`: **0 plugin source files** pulled in (was dozens), **0 errors**, exit 0.
- [x] `node scripts/generate-types.mjs` produces a plugin-free `dist/traits/index.d.ts`.
- [x] Generator syntax validated (`node --check`).
- [ ] Studio Docker build green without the `|| true` tolerance (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)