### PR TITLE
[codex] pivot mesh-worker hardware policy

### DIFF
--- a/docs/headless-agents.md
+++ b/docs/headless-agents.md
@@ -17,9 +17,9 @@ deployment status, and the composition file that drives it.
 | Field | Value |
 |---|---|
 | Handle | `mesh-worker-01` |
-| Provider | `local-llm` (H200 flagship) |
-| Model | `Qwen/Qwen2.5-72B-Instruct-AWQ` |
-| Purpose | Lean 4 theorem proving, formal verification, mathematical reasoning for Paper program |
+| Provider | `local-llm` (capability lane; not H200-pinned) |
+| Model | `Qwen/Qwen2.5-14B-Instruct-AWQ` |
+| Purpose | Paper 25 trusted-corpus work by default; Lean 4 / formal-verification escalation only when a manifest justifies H100/H200-class hardware |
 | Status | **ACTIVE** |
 
 ### `trait-inference-brain.hsplus`

--- a/scripts/mesh-deploy/README.md
+++ b/scripts/mesh-deploy/README.md
@@ -120,7 +120,10 @@ For each successfully bootstrapped instance:
   - `local-llm` on the GPU: $0 LLM (compute is base burn)
   - `anthropic` Claude Opus 4.7: ~$3-15/day depending on tick rate + task complexity. Capped by `budgetUsdPerDay`.
 - Worst case 31 anthropic agents × $5/day budget = $155/day LLM cost. Cap via `globalBudgetUsdPerDay` in agents.json.
-- Recommended starting mix per template: 1 anthropic (H200), 25 local-llm, 5 mock = ~$5/day total LLM cost.
+- Recommended starting mix per template: 1 local-llm primary capability lane,
+  25 local-llm warm lanes, 5 mock = $0/day LLM cost plus the approved Vast
+  compute burn. H100/H200 should be rented only when the active manifest proves
+  the cheaper capability tier cannot satisfy the output gate.
 
 ---
 

--- a/scripts/mesh-deploy/agents-template.json
+++ b/scripts/mesh-deploy/agents-template.json
@@ -1,5 +1,5 @@
 {
-  "_README": "Template for the 31-instance mesh deployment. Each entry maps one Vast.ai instance → one mesh agent identity. The deploy script (Deploy-MeshAgents.ps1) joins this with the live `vastai show instances` listing to produce per-instance env files. Order matters — entries assigned to instances in the order Vast.ai returns them. Provider mix: Anthropic-backed agents are richest but rate-limited + costly; local-llm agents run on the GPU itself for $0 LLM cost (just compute burn). Mock agents validate the runtime without LLM cost.",
+  "_README": "Template for the 31-instance mesh deployment. Each entry maps one Vast.ai instance -> one mesh agent identity. The deploy script (Deploy-MeshAgents.ps1) joins this with the live `vastai show instances` listing to produce per-instance env files. Order matters only for unlabeled legacy instances; W.111 labels win. Provider mix: local-llm agents run on the GPU itself for $0 LLM cost (just compute burn). Mock agents validate the runtime without LLM cost. 2026-05-27 pivot: the primary lane is capability-first, not H200-first.",
 
   "_provisioning_status": "TEMPLATE — wallet + x402 bearer fields are placeholders. Founder must: (1) provision N x402 seats on the HoloMesh team-board, (2) generate N wallets, (3) substitute placeholders below. Per F.027/F.002: x402 seat creation is founder authority; agent must NOT auto-provision.",
 
@@ -8,33 +8,19 @@
 
   "agents": [
     {
-      "_role": "H200 powerhouse — runs Qwen 72B-AWQ locally on 140GB HBM3e. Founder directive 2026-04-26: switched from Anthropic-backed Claude to local-llm because Anthropic API spend ran $21+ in <2h with 0 CAEL records produced (mw01 wedged in over-budget loop pre-cap-removal, then hit 'credit balance too low' post-restart). Local 72B at this tier produces production-grade reasoning + coding output (per gpu-tier-models.json) at $0 per-token cost — only the Vast hourly rental ($91/d). Supervisor-style coordination still works; just costs less.",
-      "handle": "mesh-h200-flagship",
+      "_role": "Primary capability lane - runs Qwen 14B-AWQ locally on the cheapest whole-machine host that can satisfy the active manifest. H100/H200 is reserved for evidence-backed escalation, not the default Paper 25 corpus worker.",
+      "handle": "mesh-capability-primary",
+      "instanceMatch": "RTX 5060 Ti|RTX 5080|RTX 4090|RTX 3090|RTX A5000|RTX 6000|L40S|A100|H100|H200",
       "brainPath": "compositions/lean-theorist-brain.hsplus",
       "provider": "local-llm",
-      "model": "Qwen/Qwen2.5-72B-Instruct-AWQ",
-      "walletEnvKey": "HOLOSCRIPT_AGENT_WALLET_H200",
-      "bearerEnvKey": "HOLOSCRIPT_AGENT_X402_BEARER_H200",
-      "budgetUsdPerDay": 0,
+      "model": "Qwen/Qwen2.5-14B-Instruct-AWQ",
+      "walletEnvKey": "HOLOSCRIPT_AGENT_WALLET_PRIMARY",
+      "bearerEnvKey": "HOLOSCRIPT_AGENT_X402_BEARER_PRIMARY",
+      "budgetUsdPerDay": 50,
       "scopeTier": "hot",
       "enabled": true,
       "tickIntervalMs": 30000,
-      "enableCommitHook": true,
-      "_sidecar_note": "AMBER §7.2 example: Goedel-V2-7B Lean-specialist sidecar co-located on H200 (88GB total fits in 140GB HBM3e per §7.1). Schema parsed + validated by deploy.py. Execution path (screen -dmS startup, health-check, env dispatch) wired in deploy_one.",
-      "sidecars": [
-        {
-          "name": "lean-prover",
-          "model": "Goedel-LM/Goedel-Prover-V2-7B",
-          "port": 8082,
-          "vram_estimate_gb": 14,
-          "max_model_len": 4096,
-          "vllm_args": [
-            "--enforce-eager",
-            "--gpu-memory-utilization=0.10"
-          ],
-          "consumed_by_env_var": "LEAN_SPECIALIST_URL"
-        }
-      ]
+      "enableCommitHook": true
     },
     {
       "_role": "Local-LLM — Qwen 0.5B running directly on the GPU. Zero LLM API cost; pure compute burn. Brain: trait-inference. Best for the trait-inference work that's already speced.",
@@ -78,7 +64,7 @@
   ],
 
   "_brain_distribution_plan": {
-    "lean-theorist-brain.hsplus": "1 instance (H200 flagship — anthropic-backed for paper-22+23 proof work)",
+    "lean-theorist-brain.hsplus": "1 primary capability lane (14B-class by default; H100/H200 only for evidence-backed escalation)",
     "security-auditor-brain.hsplus": "5 instances (paper-21 attack surface enumeration + threat-model expansion)",
     "trait-inference-brain.hsplus": "10 instances (paper-19 dataset generation — local-llm Brittney synth)",
     "sesl-training-brain.hsplus": "5 instances (paper-17 self-play harness exploration; mock or local-llm)",

--- a/scripts/mesh-deploy/agents.json
+++ b/scripts/mesh-deploy/agents.json
@@ -1,5 +1,5 @@
 {
-  "_README": "Auto-generated 2026-04-24 by ai-ecosystem session after provisioning 31 x402 seats via scripts/provision-mesh-seats.mjs. Brain distribution per agents-template.json _brain_distribution_plan, with the H200 instance reserved for the anthropic-backed lean-theorist flagship (highest-value brain on the highest-throughput hardware).",
+  "_README": "Auto-generated 2026-04-24 by ai-ecosystem session after provisioning 31 x402 seats via scripts/provision-mesh-seats.mjs. 2026-05-27 pivot: mesh-worker-01 is a capability lane, not an H200 entitlement. The live config starts with 14B-class whole-machine hosts and escalates to H100/H200 only when the active manifest proves the cheaper tier cannot satisfy the output gate.",
 
   "_provisioning_provenance": {
     "provisioned_at": "2026-04-24T23:50:35Z (approx)",
@@ -15,34 +15,19 @@
 
   "agents": [
     {
-      "_role": "H200 FLAGSHIP — local-llm Qwen 72B-AWQ running lean-theorist-brain. Founder directive 2026-04-25 (commit 97efb061c) flipped this from anthropic claude-opus-4-7 → local-llm because Anthropic API spend ran $21+ in <2h with 0 CAEL records produced (mw01 wedged in over-budget loop). 2026-04-25 commit landed on agents-template.json but NOT agents.json (drift caught 2026-04-26 readiness audit); this edit closes that drift. Use the H200's 141GB VRAM for hot-tier brain context. instanceMatch=H200 pins this to the H200 instance. Sidecar: Goedel-V2-7B Lean-specialist co-located on the same H200 (88GB total fits in 140GB per AMBER memo §7.1).",
+      "_role": "Capability lane - local-llm Qwen 14B-AWQ running lean-theorist-brain for Paper 25 trusted-corpus and other manifest-backed work. This is intentionally not H200-pinned: use the cheapest whole-machine host that can satisfy the active output gate under the lane cap. H100/H200 is an escalation tier for non-substitutable 70B/Lean-sidecar work, not the default.",
       "handle": "mesh-worker-01",
-      "instanceMatch": "H200",
+      "instanceMatch": "RTX 5060 Ti|RTX 5080|RTX 4090|RTX 3090|RTX A5000|RTX 6000|L40S|A100|H100|H200",
       "brainPath": "compositions/lean-theorist-brain.hsplus",
       "provider": "local-llm",
-      "model": "Qwen/Qwen2.5-72B-Instruct-AWQ",
+      "model": "Qwen/Qwen2.5-14B-Instruct-AWQ",
       "walletEnvKey": "HOLOMESH_WALLET_MESH_01_X402",
       "bearerEnvKey": "HOLOMESH_API_KEY_MESH_01_X402",
-      "budgetUsdPerDay": 0,
+      "budgetUsdPerDay": 50,
       "scopeTier": "hot",
       "enabled": true,
       "tickIntervalMs": 30000,
-      "enableCommitHook": true,
-      "_sidecar_note": "AMBER §7.2: Goedel-V2-7B Lean-specialist sidecar. Execution path (screen -dmS startup, health-check, env dispatch) wired in deploy.py deploy_one. Schema validates via --validate-only.",
-      "sidecars": [
-        {
-          "name": "lean-prover",
-          "model": "Goedel-LM/Goedel-Prover-V2-7B",
-          "port": 8082,
-          "vram_estimate_gb": 14,
-          "max_model_len": 4096,
-          "vllm_args": [
-            "--enforce-eager",
-            "--gpu-memory-utilization=0.10"
-          ],
-          "consumed_by_env_var": "LEAN_SPECIALIST_URL"
-        }
-      ]
+      "enableCommitHook": true
     },
     {
       "_role": "Trait-inference local-llm worker — Qwen 0.5B running on the GPU directly. Zero LLM API cost (compute already paid). Brain: trait-inference. Used for paper-19 dataset generation + trait-classification work.",


### PR DESCRIPTION
﻿1. **Objective**: Pivot `mesh-worker-01` from an H200 entitlement to a capability-first lane so Paper 25 defaults to the cheapest whole-machine host that can satisfy the trusted-corpus evidence floor, with H100/H200 reserved for evidence-backed escalation.

2. **Hardware Validation**: Targeted validation passed:
   - JSON parse for `scripts/mesh-deploy/agents.json` and `scripts/mesh-deploy/agents-template.json`
   - `git diff --check -- scripts/mesh-deploy/agents.json scripts/mesh-deploy/agents-template.json docs/headless-agents.md scripts/mesh-deploy/README.md`
   - `python scripts\mesh-deploy\deploy.py --config scripts\mesh-deploy\agents.json --validate-only`
   - `python scripts\mesh-deploy\deploy.py --config scripts\mesh-deploy\agents-template.json --validate-only`
   - Planner smoke test confirmed `mesh-worker-01` matches an `RTX 4090` through the widened `instanceMatch` policy.

   `pnpm build` was not run for this docs/config-only draft. `pwsh baseline_audit.ps1` was not run because `baseline_audit.ps1` is absent in this checkout.

3. **Impact Analysis**: Local blast radius is limited to mesh deployment policy/config and docs: `docs/headless-agents.md`, `scripts/mesh-deploy/README.md`, `scripts/mesh-deploy/agents-template.json`, and `scripts/mesh-deploy/agents.json`. Formal `holo_impact_analysis` was not run in this Codex harness; no package source or runtime code paths changed.

4. **Merge Requirement**: Squash to maintain linear history. Merge is needed before the ai-ecosystem fleet publisher stops seeing the old H200-only `mesh-worker-01` policy from HoloScript main.
