### PR TITLE
Resolve 6 genuine TypeScript errors across core/engine

### DIFF
--- a/packages/core/scripts/generate-types.mjs
+++ b/packages/core/scripts/generate-types.mjs
@@ -3240,7 +3240,7 @@ export class CircuitBreakerRegistry { [key: string]: any; }
 export class CircuitState { [key: string]: any; }
 export class ExportManager { [key: string]: any; }
 export declare function getExportManager(options?: Partial<ExportOptions>): any;
-export class ExportTarget { [key: string]: any; }
+export type ExportTarget = 'urdf' | 'sdf' | 'unity' | 'unreal' | 'godot' | 'vrchat' | 'openxr' | 'android' | 'android-xr' | 'ios' | 'visionos' | 'ar' | 'babylon' | 'webgpu' | 'r3f' | 'wasm' | 'playcanvas' | 'usd' | 'usdz' | 'dtdl' | 'vrr' | 'multi-layer' | 'incremental' | 'state' | 'trait-composition' | 'tsl' | 'a2a-agent-card' | 'nir' | 'openxr-spatial-entities' | 'phone-sleeve-vr' | 'native-2d' | 'context' | '3dgs';
 export class ExportOptions { [key: string]: any; }
 export declare function selectModality(platform: any, options?: any): any;
 export declare function selectModalityForAll(options?: any): Map<any, any>;

--- a/packages/core/src/compiler/ARCompiler.ts
+++ b/packages/core/src/compiler/ARCompiler.ts
@@ -165,7 +165,7 @@ export class ARCompiler extends CompilerBase {
     return traitName.startsWith('@') ? traitName.slice(1) : traitName;
   }
 
-  private isObjectDecl(record: Record<string, unknown>): record is HoloObjectDecl {
+  private isObjectDecl(record: Record<string, unknown>): record is Record<string, unknown> & HoloObjectDecl {
     return (
       (record.type === 'Object' || record.type === 'ObjectDecl') &&
       typeof record.name === 'string' &&

--- a/packages/core/src/compiler/NodeServiceCompiler.ts
+++ b/packages/core/src/compiler/NodeServiceCompiler.ts
@@ -339,8 +339,8 @@ export class NodeServiceCompiler extends CompilerBase {
     const path = this.resolveString(propMap.get('path')) || `/${this.toKebab(obj.name)}`;
     const handlerName =
       this.resolveString(propMap.get('handler')) ||
-      this.resolveString(this.readTraitConfig(handlerTrait, 'name', 'handler')) ||
-      this.resolveString(this.readTraitConfig(handlerTrait, '_arg0')) ||
+      this.resolveString(this.readTraitConfig(handlerTrait, 'name', 'handler') as HoloValue | undefined) ||
+      this.resolveString(this.readTraitConfig(handlerTrait, '_arg0') as HoloValue | undefined) ||
       this.toCamelCase(obj.name);
 
     // Only generate route if there are http-related properties or traits

--- a/packages/core/src/traits/TwinActuatorTrait.ts
+++ b/packages/core/src/traits/TwinActuatorTrait.ts
@@ -80,7 +80,7 @@ export const twinActuatorHandler: TraitHandler<TwinActuatorConfig> = {
       // Structural civilian-harm impossibility check (D.044):
       // every actuation must pass a validated safety envelope before reaching
       // the actuation path. Missing envelope = illegal state = blocked.
-      const envelopeCheck = validateSafetyEnvelope(config.safety_envelope, action, node.id);
+      const envelopeCheck = validateSafetyEnvelope(config.safety_envelope, action, node.id ?? '<unknown>');
       if (!envelopeCheck.ok) {
         context.emit('twin_actuator_error', {
           node,

--- a/packages/engine/src/simulation/StructuralSolver.ts
+++ b/packages/engine/src/simulation/StructuralSolver.ts
@@ -486,7 +486,7 @@ export class StructuralSolver {
 
       for (let row = 0; row < this.dofCount; row++) {
         if (this.constrainedDofs.has(row)) continue;
-        const rowMap = this.dofToCSR.get(row);
+        const rowMap: Map<number, number> | undefined = this.dofToCSR.get(row);
         const idx = rowMap?.get(dof);
         if (idx !== undefined) this.csrVal[idx] = 0.0;
       }


### PR DESCRIPTION
## Summary

Lands 6 genuine, build-independent TypeScript fixes (stranded on a stalled branch) after peer review.

- `ExportTarget` in the generated type stub → proper string-literal union instead of `class { [key: string]: any }`.
- `ARCompiler.isObjectDecl` type guard → `record is Record<string, unknown> & HoloObjectDecl` (valid narrowing from the input type).
- `NodeServiceCompiler` → `HoloValue | undefined` casts on `readTraitConfig` results.
- `TwinActuatorTrait` → `node.id ?? '<unknown>'` guard on the safety-envelope path (`node.id` is optional).
- `StructuralSolver` → explicit `Map<number, number> | undefined` annotation.

## Peer review / validation

- All 5 changes reviewed; each addresses a real, build-independent type error (not a cascade from unbuilt sibling packages).
- Verified `@holoscript/engine` type-checks with **0 genuine errors** with this applied (also covers the `StructuralSolver` change).
- Confirmed the remaining core tsc errors (ConsensusTrait `mechanism`, SpatialAwareness `perceptionRadius`/`entityTypeFilter`) are **false positives from the unbuilt `@holoscript/mesh` dependency** — those properties exist in `ConsensusConfig` (mesh `ConsensusTypes.ts:22`); not touched here.
- Merges cleanly into `main`.

## Test plan

- [x] `@holoscript/engine` `tsc --noEmit` — 0 genuine errors
- [x] Core fixed files (`ARCompiler`, `NodeServiceCompiler`, `TwinActuatorTrait`) — target errors resolved

https://claude.ai/code/session_018DGmv7ZGq9ZDbEqTY5F77m

---
_Generated by [Claude Code](https://claude.ai/code/session_018DGmv7ZGq9ZDbEqTY5F77m)_