### PR TITLE
Make StagedMatter.consolidate() provenanceHash deterministic (D.059)

### DIFF
--- a/packages/core/src/matter/StagedMatter.ts
+++ b/packages/core/src/matter/StagedMatter.ts
@@ -102,21 +102,26 @@ export function consolidate(unitA: MatterUnit, unitB: MatterUnit): MatterUnit {
   mergedHashes.sort();
 
   // ── Build new derivation edges for this consolidation step ──
+  // Use empty strings for `to` and `timestamp` during hash computation so the
+  // hash is a pure function of (unitA, unitB) and does not change across calls.
+  // Both fields are filled in after the result hash is known.
   const newEdgeA: DerivationEdge = {
     from: unitA.provenanceHash,
-    to: '', // filled after we compute the result hash
+    to: '',
     operation: 'consolidate',
-    timestamp: now,
+    timestamp: '',
   };
   const newEdgeB: DerivationEdge = {
     from: unitB.provenanceHash,
-    to: '', // filled after we compute the result hash
+    to: '',
     operation: 'consolidate',
-    timestamp: now,
+    timestamp: '',
   };
 
-  // ── Assemble merged manifest ──
-  const mergedManifest: MatterManifest = {
+  // ── Compute content-addressable provenance hash ──
+  // Hash is computed from a canonical manifest with stable (empty) to/timestamp
+  // fields so that consolidate(A, B) always yields the same provenanceHash.
+  const hashManifest: MatterManifest = {
     schema: 'matter-manifest/v1',
     provenanceHashes: mergedHashes,
     derivationEdges: [
@@ -126,19 +131,14 @@ export function consolidate(unitA: MatterUnit, unitB: MatterUnit): MatterUnit {
       newEdgeB,
     ],
   };
+  const resultHash = computeProvenanceHash(hashManifest);
 
-  // ── Compute content-addressable provenance hash ──
-  const resultHash = computeProvenanceHash(mergedManifest);
-
-  // Patch the 'to' fields now that we know the result hash
+  // Fill in the non-deterministic fields after the hash is fixed.
   newEdgeA.to = resultHash;
+  newEdgeA.timestamp = now;
   newEdgeB.to = resultHash;
+  newEdgeB.timestamp = now;
 
-  // Re-assemble with patched edges (same hash because patching 'to'
-  // happens AFTER hash computation, and the hash was computed from
-  // the pre-patch edges where 'to' was empty. This is intentional:
-  // the hash is of the structural merge, not the self-referential closure.
-  // For a self-referential version, use computeProvenanceHash after patching.)
   const finalManifest: MatterManifest = {
     schema: 'matter-manifest/v1',
     provenanceHashes: mergedHashes,


### PR DESCRIPTION
## Summary

Makes `StagedMatter.consolidate()`'s `provenanceHash` deterministic (D.059): the hash is now computed from a canonical manifest with stable (empty) `to`/`timestamp` edge fields, which are filled in *after* the hash is fixed. So `consolidate(A, B)` always yields the same `provenanceHash` regardless of wall-clock time.

## Peer review / validation

- Merges cleanly into `main`. Single file: `packages/core/src/matter/StagedMatter.ts`.
- StagedMatter tests (`staged-matter.test.ts`, `StagedMatter.test.ts`) — **21/21 passing** on the merged state.
- Note: `MatterpakCompiler.test.ts` shows 10 failures, but those are **pre-existing on clean `main`** and unrelated to this change (different file/subsystem).

https://claude.ai/code/session_018DGmv7ZGq9ZDbEqTY5F77m

---
_Generated by [Claude Code](https://claude.ai/code/session_018DGmv7ZGq9ZDbEqTY5F77m)_