### PR TITLE
fix(core): correct LCG float divisor to exclude 1.0 from RNG output range

### DIFF
--- a/packages/core/src/world-model/AdversarialMutator.ts
+++ b/packages/core/src/world-model/AdversarialMutator.ts
@@ -105,7 +105,7 @@ function makeRng(seed: number): Rng {
   let state = (seed >>> 0) || 1;
   const float = (): number => {
     state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 0xffffffff;
+    return state / 0x100000000;
   };
   const int = (min: number, max: number): number =>
     min + Math.floor(float() * (max - min + 1));


### PR DESCRIPTION
Auto-rescued from stalled branch (2026-05-28 cleanup pass — Phase E, TRY-REBASE bucket). No path conflicts with current main.