### PR TITLE
feat(hologram): receipt-to-pixels binding — embed source receipt hash in rende

### DIFF
--- a/packages/engine/src/hologram/HologramBundle.ts
+++ b/packages/engine/src/hologram/HologramBundle.ts
@@ -41,6 +41,19 @@ export interface HologramMeta {
   schemaVersion: 1;
 }
 
+/**
+ * Render output manifest — binds the rendered output to its source receipt.
+ * Per D.058: receipt must ride to the pixels.
+ */
+export interface HologramManifest {
+  /** Content-addressed hash of the source state (bundle identity) */
+  sourceHash: string;
+  /** Receipt type discriminator */
+  receiptType: 'bundle-hash';
+  /** ISO8601 timestamp of manifest creation */
+  createdAt: string;
+}
+
 export interface HologramBundle {
   /**
    * Content-addressed identifier. SHA-256 hex of canonical
@@ -50,6 +63,8 @@ export interface HologramBundle {
    */
   hash: string;
   meta: HologramMeta;
+  /** Render output manifest carrying the source receipt hash */
+  manifest: HologramManifest;
   /** Float32 depth map, row-major, values in [0,1] (0=near, 1=far) */
   depthBin: Uint8Array;
   /** Float32 RGB normal map, row-major, values in [0,1] */

--- a/packages/engine/src/hologram/createHologram.test.ts
+++ b/packages/engine/src/hologram/createHologram.test.ts
@@ -398,6 +398,25 @@ describe('createHologram — happy path', () => {
     expect(gif.meta.sourceKind).toBe('gif');
     expect(vid.meta.sourceKind).toBe('video');
   });
+
+  it('embeds source receipt hash in render output manifest (D.058)', async () => {
+    const bundle = await createHologram(
+      new Uint8Array([0xff, 0xd8, 0xff]),
+      'image',
+      fullProviders(),
+      { targets: ['quilt'] }
+    );
+
+    // Failing-if-broken: manifest must exist and carry the source hash
+    expect(bundle.manifest).toBeDefined();
+    expect(bundle.manifest.sourceHash).toBe(bundle.hash);
+    expect(bundle.manifest.receiptType).toBe('bundle-hash');
+    expect(bundle.manifest.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Recompute hash from identity fields and verify it matches manifest.sourceHash
+    const recomputed = await computeBundleHash(bundle.meta, bundle.depthBin, bundle.normalBin);
+    expect(bundle.manifest.sourceHash).toBe(recomputed);
+  });
 });
 
 describe('createHologram — sequentialRender', () => {

--- a/packages/engine/src/hologram/createHologram.ts
+++ b/packages/engine/src/hologram/createHologram.ts
@@ -30,6 +30,7 @@ import { depthToNormalMap } from './DepthEstimationService';
 import {
   computeBundleHash,
   type HologramBundle,
+  type HologramManifest,
   type HologramMeta,
   type HologramSourceKind,
   type HologramTarget,
@@ -404,8 +405,15 @@ export async function createHologram(
     );
   }
 
-  // ── 7. Assemble bundle ──
-  const bundle: HologramBundle = { hash, meta, depthBin, normalBin };
+  // ── 7. Build manifest (receipt-to-pixels binding per D.058) ──
+  const manifest: HologramManifest = {
+    sourceHash: hash,
+    receiptType: 'bundle-hash',
+    createdAt: now().toISOString(),
+  };
+
+  // ── 8. Assemble bundle ──
+  const bundle: HologramBundle = { hash, meta, manifest, depthBin, normalBin };
   for (const [target, bytes] of rendered) {
     if (target === 'quilt') bundle.quiltPng = bytes;
     else if (target === 'mvhevc') bundle.mvhevcMp4 = bytes;

--- a/packages/hologram-worker/src/server.ts
+++ b/packages/hologram-worker/src/server.ts
@@ -261,6 +261,7 @@ const server = createServer(async (req, res) => {
           hash,
           shareUrl,
           targets,
+          manifest: bundle.manifest,
           mvhevcUrl: publicBase
             ? `${publicBase.replace(/\/$/, '')}/api/hologram/${hash}/mvhevc.mp4`
             : '',


### PR DESCRIPTION
Auto-rescued from stalled branch (2026-05-28 cleanup pass — research/2026-05-28_branch-sprawl-triage-plan.md). Net LOC: 55, last commit: 2026-05-25, 3 days old.