### PR TITLE
fix(mcp-server): retire 6 dead test_* MCP tools and add PluginManager.reset()

### DIFF
--- a/packages/mcp-server/src/PluginManager.test.ts
+++ b/packages/mcp-server/src/PluginManager.test.ts
@@ -6,47 +6,53 @@
  * - Tool retrieval
  * - Tool handling dispatch
  * - Unknown tool handling
+ * - reset() clears all state
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PluginManager } from './PluginManager.js';
 
 describe('PluginManager', () => {
-  // Note: PluginManager uses static state — tests may interact.
-  // We test behavior rather than exact counts.
+  // Reset static state between tests to prevent test tool names
+  // from leaking into the production tool list.
+  beforeEach(() => {
+    PluginManager.reset();
+  });
+
+  afterEach(() => {
+    PluginManager.reset();
+  });
 
   describe('registerPlugin', () => {
     it('registers tools', async () => {
-      const initialCount = PluginManager.getTools().length;
       await PluginManager.registerPlugin(
         [
           {
-            name: 'test_tool_1',
+            name: '_unit_test_tool_1',
             description: 'A test tool',
             inputSchema: { type: 'object' as const },
           },
         ],
         async (name, args) => ({ result: 'ok' })
       );
-      expect(PluginManager.getTools().length).toBe(initialCount + 1);
+      expect(PluginManager.getTools().length).toBe(1);
     });
 
     it('registers multiple tools at once', async () => {
-      const initialCount = PluginManager.getTools().length;
       await PluginManager.registerPlugin(
         [
-          { name: 'multi_1', description: 'Multi 1', inputSchema: { type: 'object' as const } },
-          { name: 'multi_2', description: 'Multi 2', inputSchema: { type: 'object' as const } },
+          { name: '_unit_multi_1', description: 'Multi 1', inputSchema: { type: 'object' as const } },
+          { name: '_unit_multi_2', description: 'Multi 2', inputSchema: { type: 'object' as const } },
         ],
         async () => ({ result: 'multi' })
       );
-      expect(PluginManager.getTools().length).toBe(initialCount + 2);
+      expect(PluginManager.getTools().length).toBe(2);
     });
 
     it('blocks hostile plugin manifest', async () => {
       await expect(
         PluginManager.registerPlugin(
-          [{ name: 'bad_tool', description: 'bad', inputSchema: { type: 'object' as const } }],
+          [{ name: '_unit_bad_tool', description: 'bad', inputSchema: { type: 'object' as const } }],
           async () => 'bad',
           { name: 'bad', scopeName: '@evil', version: '1.0.0', trustTier: 'unverified' }
         )
@@ -54,13 +60,12 @@ describe('PluginManager', () => {
     });
 
     it('allows benign plugin manifest', async () => {
-      const initialCount = PluginManager.getTools().length;
       await PluginManager.registerPlugin(
-        [{ name: 'good_tool', description: 'good', inputSchema: { type: 'object' as const } }],
+        [{ name: '_unit_good_tool', description: 'good', inputSchema: { type: 'object' as const } }],
         async () => 'good',
         { name: 'good', scopeName: '@holoscript', version: '1.0.0', trustTier: 'verified' }
       );
-      expect(PluginManager.getTools().length).toBe(initialCount + 1);
+      expect(PluginManager.getTools().length).toBe(1);
     });
   });
 
@@ -74,16 +79,32 @@ describe('PluginManager', () => {
   describe('handleTool', () => {
     it('dispatches to registered handler', async () => {
       await PluginManager.registerPlugin(
-        [{ name: 'dispatch_test', description: 'Test', inputSchema: { type: 'object' as const } }],
+        [{ name: '_unit_dispatch_test', description: 'Test', inputSchema: { type: 'object' as const } }],
         async (name, args) => ({ handled: true, name, args })
       );
-      const result = await PluginManager.handleTool('dispatch_test', { x: 1 });
-      expect(result).toEqual({ handled: true, name: 'dispatch_test', args: { x: 1 } });
+      const result = await PluginManager.handleTool('_unit_dispatch_test', { x: 1 });
+      expect(result).toEqual({ handled: true, name: '_unit_dispatch_test', args: { x: 1 } });
     });
 
     it('returns null for unregistered tools', async () => {
-      const result = await PluginManager.handleTool('nonexistent_tool', {});
+      const result = await PluginManager.handleTool('nonexistent_tool_xyz', {});
       expect(result).toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all registered tools and handlers', async () => {
+      await PluginManager.registerPlugin(
+        [{ name: '_unit_reset_tool', description: 'Reset test', inputSchema: { type: 'object' as const } }],
+        async () => 'ok'
+      );
+      expect(PluginManager.getTools().length).toBe(1);
+      expect(await PluginManager.handleTool('_unit_reset_tool', {})).toEqual('ok');
+
+      PluginManager.reset();
+
+      expect(PluginManager.getTools().length).toBe(0);
+      expect(await PluginManager.handleTool('_unit_reset_tool', {})).toBeNull();
     });
   });
 });

--- a/packages/mcp-server/src/PluginManager.ts
+++ b/packages/mcp-server/src/PluginManager.ts
@@ -72,4 +72,14 @@ export class PluginManager {
     }
     return null;
   }
+
+  /**
+   * Reset all registered plugin state (tools + handlers).
+   * For use in test afterEach / beforeEach to prevent test tool names
+   * from leaking into the production tool list via static state.
+   */
+  static reset(): void {
+    this.tools = [];
+    this.handlers.clear();
+  }
 }

--- a/packages/mcp-server/src/__tests__/api-docs-generator.test.ts
+++ b/packages/mcp-server/src/__tests__/api-docs-generator.test.ts
@@ -8,7 +8,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 function makeTool(overrides: Partial<Tool> = {}): Tool {
   return {
-    name: overrides.name || 'test_tool',
+    name: overrides.name || '_unit_docs_tool',
     description: overrides.description || 'A test tool',
     inputSchema: overrides.inputSchema || {
       type: 'object' as const,
@@ -62,7 +62,7 @@ describe('APIDocsGenerator', () => {
   describe('tool documentation', () => {
     it('documents parameters', () => {
       const tool = makeTool({
-        name: 'test_tool',
+        name: '_unit_docs_params',
         inputSchema: {
           type: 'object' as const,
           properties: {
@@ -160,7 +160,7 @@ describe('APIDocsGenerator', () => {
 
   describe('JSON output', () => {
     it('generates valid JSON', () => {
-      const tools = [makeTool({ name: 'test_tool' })];
+      const tools = [makeTool({ name: '_unit_docs_json' })];
       const ref = generator.generate(tools);
       const json = generator.toJSON(ref);
 

--- a/packages/mcp-server/src/__tests__/fork-sandbox-canary.test.ts
+++ b/packages/mcp-server/src/__tests__/fork-sandbox-canary.test.ts
@@ -14,7 +14,7 @@
  * was bypassed, disabled, or not wired."
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { handleTool } from '../handlers';
 import { PluginManager } from '../PluginManager';
 import { globalReceiptStore } from '../security/sandbox-policy';
@@ -288,6 +288,10 @@ describe('canary: fork sandbox gate is wired at every sensitive entry point', ()
       policyId: expect.any(String),
       checks: expect.any(Array),
     });
+  });
+
+  afterEach(() => {
+    PluginManager.reset();
   });
 
   it('CANARY-W002: PluginManager.registerPlugin blocks hostile manifest', async () => {

--- a/packages/mcp-server/src/__tests__/holo-graph-visualization.test.ts
+++ b/packages/mcp-server/src/__tests__/holo-graph-visualization.test.ts
@@ -3,7 +3,7 @@
  * Covers: parseHoloToGraph, visualizeFlow, getNodeConnections,
  *         designGraphFromDescription, PluginManager, handleIDETool
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   parseHoloToGraph,
   visualizeFlow,
@@ -335,10 +335,14 @@ describe('designGraphFromDescription', () => {
 // PluginManager
 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
 describe('PluginManager', () => {
-  // Reset static state between tests
+  // Reset static state between tests to prevent test tool names
+  // from leaking into the production tool list.
   beforeEach(() => {
-    // Clear via registration overwrite - can't reset static directly,
-    // but tests are additive so we just ensure registration works
+    PluginManager.reset();
+  });
+
+  afterEach(() => {
+    PluginManager.reset();
   });
 
   it('is importable as a class', () => {
@@ -351,18 +355,17 @@ describe('PluginManager', () => {
   });
 
   it('registerPlugin adds tools', async () => {
-    const before = PluginManager.getTools().length;
     await PluginManager.registerPlugin(
       [
         {
-          name: 'test_sprint59_tool',
+          name: '_unit_sprint59_tool',
           description: 'Test tool',
           inputSchema: { type: 'object' as const, properties: {} },
         },
       ],
       async () => ({ result: 'ok' })
     );
-    const after = PluginManager.getTools().length;
+    expect(PluginManager.getTools().length).toBe(1);
     expect(after).toBe(before + 1);
   });
 
@@ -370,14 +373,14 @@ describe('PluginManager', () => {
     await PluginManager.registerPlugin(
       [
         {
-          name: 'test_sprint59_echo',
+          name: '_unit_sprint59_echo',
           description: 'Echo tool',
           inputSchema: { type: 'object' as const, properties: {} },
         },
       ],
       async (_name, args) => ({ echoed: args.value })
     );
-    const result = await PluginManager.handleTool('test_sprint59_echo', { value: 'hello' });
+    const result = await PluginManager.handleTool('_unit_sprint59_echo', { value: 'hello' });
     expect(result).toEqual({ echoed: 'hello' });
   });
 
@@ -391,12 +394,12 @@ describe('PluginManager', () => {
     await PluginManager.registerPlugin(
       [
         {
-          name: 'test_multi_a',
+          name: '_unit_multi_a',
           description: 'a',
           inputSchema: { type: 'object' as const, properties: {} },
         },
         {
-          name: 'test_multi_b',
+          name: '_unit_multi_b',
           description: 'b',
           inputSchema: { type: 'object' as const, properties: {} },
         },
@@ -406,8 +409,8 @@ describe('PluginManager', () => {
         return {};
       }
     );
-    await PluginManager.handleTool('test_multi_a', {});
-    await PluginManager.handleTool('test_multi_b', {});
+    await PluginManager.handleTool('_unit_multi_a', {});
+    await PluginManager.handleTool('_unit_multi_b', {});
     expect(calls).toBe(2);
   });
 });


### PR DESCRIPTION
Auto-rescued from stalled branch (2026-05-28 cleanup pass — research/2026-05-28_branch-sprawl-triage-plan.md). Net LOC: 110, last commit: 2026-05-26, 2 days old.