### PR TITLE
fix(engine): restore RenderManifold + ConjectureRunner cost-cell exports

### DIFF
--- a/packages/engine/src/simulation/ConjectureRunner.ts
+++ b/packages/engine/src/simulation/ConjectureRunner.ts
@@ -7,6 +7,7 @@
 import {
   buildConjectureStableKey,
   buildConjectureV1Receipt,
+  computeMeshFacts,
   createDegenerateTriangleCandidate,
   createSquareSheetCandidate,
   createTetrahedronSurfaceCandidate,
@@ -38,6 +39,10 @@ import type { SemanticCorpusIndex } from './SemanticCorpusIndex';
 import type { SemanticNoveltyAssessment } from './SemanticNoveltyEncoder';
 import { stableStringify } from './equivalenceRecord';
 import type { HashMode } from './hashes';
+import {
+  renderManifoldFromReceipts,
+  type RenderManifoldArtifact,
+} from './RenderManifold';
 
 export const CONJECTURE_RUNNER_V1 = 'conjecture.runner.v1' as const;
 export const PROOF_CARRYING_GEOMETRY_SMOKE_SUITE = 'proof-carrying-geometry-smoke' as const;
@@ -48,7 +53,7 @@ export type ConjectureRunnerSuite =
   | typeof PROOF_CARRYING_GEOMETRY_SMOKE_SUITE
   | typeof GENERATED_GEOMETRY_FAMILY_SUITE;
 export type ConjectureRunnerStatus = 'completed' | 'failed';
-export type ConjectureRunnerPhase = 'GENERATE' | 'EXECUTE' | 'FALSIFY' | 'CLASSIFY' | 'GRADUATE';
+export type ConjectureRunnerPhase = 'GENERATE' | 'EXECUTE' | 'FALSIFY' | 'CLASSIFY' | 'GRADUATE' | 'RENDER';
 export type ConjectureScenarioRole = 'survivor' | 'falsifier' | 'boundary';
 export type ConjectureGraduationTarget =
   | 'receipt-carrying.geometry'
@@ -61,6 +66,51 @@ export interface ConjectureRunnerInput {
   proposedBy?: string;
   hashMode?: HashMode;
   includeHashBoundary?: boolean;
+}
+
+/** Per-probe timing record for cost-cell instrumentation. */
+export interface ConjectureProbeTiming {
+  probeId: string;
+  wallClockMs: number;
+}
+
+/** Per-candidate cost record within a cost-cell measurement. */
+export interface ConjectureCandidateCost {
+  candidateId: string;
+  family: string;
+  probeTimings: ReadonlyArray<ConjectureProbeTiming>;
+  totalProbeMs: number;
+  status: ConjectureStatus;
+}
+
+/** Cost-cell result: efficiency metrics for a single runner invocation. */
+export interface ConjectureCostCellResult {
+  solverType: string;
+  suite: string;
+  scaleCandidateCount: number;
+  totalRunnerMs: number;
+  candidates: ReadonlyArray<ConjectureCandidateCost>;
+  /** How many candidates survived / were falsified / were undecided. */
+  survivedCount: number;
+  falsifiedCount: number;
+  undecidedCount: number;
+  /** candidates-per-accepted-conjecture: total candidates / survived count. */
+  candidatesPerAcceptedConjecture: number | null;
+  /** Sum of all per-probe wall clock times across all candidates. */
+  totalProbeMs: number;
+  /** Mean per-candidate probe time. */
+  meanCandidateProbeMs: number;
+  /** Median per-candidate probe time. */
+  medianCandidateProbeMs: number;
+  /** Max per-candidate probe time. */
+  maxCandidateProbeMs: number;
+  /** Per-probe-type aggregated timing. */
+  probeTypeAggregate: ReadonlyArray<{
+    probeId: string;
+    totalMs: number;
+    meanMs: number;
+    invocationCount: number;
+  }>;
 }
 
 export interface ConjectureRunnerStage {
@@ -105,6 +155,8 @@ export interface ConjectureRunnerResult {
   replay: ReadonlyArray<ConjectureRunnerReplay>;
   gate: ConjectureRunnerGate;
   graduation: ReadonlyArray<ConjectureGraduationTarget>;
+  /** The RENDER leg: receipt-carrying render manifold artifact (P36). */
+  renderManifold: RenderManifoldArtifact;
 }
 
 export interface ConjectureRunnerSemanticAdvisory {
@@ -421,7 +473,8 @@ function buildStages(
   receipts: ReadonlyArray<ConjectureReceipt>,
   classifications: ReadonlyArray<ConjectureRunnerClassification>,
   replay: ReadonlyArray<ConjectureRunnerReplay>,
-  gate: ConjectureRunnerGate
+  gate: ConjectureRunnerGate,
+  renderManifold: RenderManifoldArtifact
 ): ReadonlyArray<ConjectureRunnerStage> {
   return [
     {
@@ -462,6 +515,14 @@ function buildStages(
           `${result.scenarioId}:receipt=${result.receiptKeyMatched}:counterexample=${result.counterexampleMatched}`
       ),
     },
+    {
+      phase: 'RENDER',
+      status: 'completed',
+      summary: 'Rendered receipt-carrying manifold surfaces with deterministic invariant-probe hash.',
+      evidence: renderManifold.surfaces.map(
+        (surface) => `${surface.candidateId}:${surface.surfaceDigest}`
+      ),
+    },
   ];
 }
 
@@ -479,6 +540,7 @@ function resultSnapshot(
     replay: result.replay,
     gate: result.gate,
     graduation: result.graduation,
+    renderManifold: result.renderManifold,
   };
 }
 
@@ -504,6 +566,10 @@ function runScenarioCycle(
     )
   );
 
+  // P36 RENDER leg: produce the receipt-carrying render manifold
+  const candidatesPerScenario = scenarios.map((scenario) => scenario.candidates);
+  const renderManifold = renderManifoldFromReceipts(receipts, candidatesPerScenario, hashMode);
+
   const withoutKey: Omit<ConjectureRunnerResult, 'receiptKey'> = {
     solverType: CONJECTURE_RUNNER_V1,
     specVersion: 1,
@@ -515,8 +581,9 @@ function runScenarioCycle(
     replay,
     gate,
     graduation,
+    renderManifold,
   };
-  const stages = buildStages(scenarios, receipts, classifications, replay, gate);
+  const stages = buildStages(scenarios, receipts, classifications, replay, gate, renderManifold);
   const withStages = { ...withoutKey, stages };
 
   return {
@@ -566,6 +633,125 @@ export class ConjectureRunner {
 
 export function runConjectureRunner(input: ConjectureRunnerInput = {}): ConjectureRunnerResult {
   return new ConjectureRunner().run(input);
+}
+
+/**
+ * Cost-cell instrumentation: run the conjecture loop at a given candidate scale,
+ * measuring candidates-per-accepted-conjecture and per-probe wall clock time.
+ *
+ * This wraps `buildConjectureV1Receipt` with timing, producing a
+ * `ConjectureCostCellResult` suitable for empirical efficiency tables.
+ */
+export function runConjectureCostCell(
+  input: ConjectureRunnerInput & { candidateScale: number }
+): ConjectureCostCellResult {
+  const { suite = PROOF_CARRYING_GEOMETRY_SMOKE_SUITE, proposedBy = DEFAULT_PROPOSED_BY, hashMode = 'sha256', includeHashBoundary = true, candidateScale } = input;
+  const scenarios =
+    suite === GENERATED_GEOMETRY_FAMILY_SUITE
+      ? buildGeneratedGeometryFamilyScenarios(proposedBy)
+      : buildProofCarryingGeometrySmokeScenarios(proposedBy, includeHashBoundary);
+
+  const runnerStart = performance.now();
+
+  const candidateCosts: ConjectureCandidateCost[] = [];
+  let survivedCount = 0;
+  let falsifiedCount = 0;
+  let undecidedCount = 0;
+  const probeTypeMap = new Map<string, { totalMs: number; invocationCount: number }>();
+
+  for (const scenario of scenarios) {
+    for (let copyIdx = 0; copyIdx < candidateScale; copyIdx++) {
+      const scaledCandidate: GeometryConjectureCandidate = copyIdx === 0
+        ? scenario.candidates[0]
+        : {
+            ...scenario.candidates[0],
+            id: `${scenario.candidates[0].id}-scale-${copyIdx}`,
+          };
+
+      const probeTimings: ConjectureProbeTiming[] = [];
+      let totalProbeMs = 0;
+
+      const facts = computeMeshFacts(scaledCandidate, hashMode);
+
+      for (const probe of scenario.probes) {
+        const probeStart = performance.now();
+        probe.evaluate(scaledCandidate, facts);
+        const probeElapsed = performance.now() - probeStart;
+        probeTimings.push({ probeId: probe.id, wallClockMs: probeElapsed });
+        totalProbeMs += probeElapsed;
+
+        const agg = probeTypeMap.get(probe.id);
+        if (agg) {
+          agg.totalMs += probeElapsed;
+          agg.invocationCount += 1;
+        } else {
+          probeTypeMap.set(probe.id, { totalMs: probeElapsed, invocationCount: 1 });
+        }
+      }
+
+      const receipt = buildConjectureV1Receipt({
+        claim: scenario.claim,
+        candidates: [scaledCandidate],
+        probes: scenario.probes,
+        hashMode,
+      });
+
+      const candidateStatus = receipt.evaluations[0]?.status ?? receipt.status;
+      if (candidateStatus === 'survived' || candidateStatus === 'rediscovered') survivedCount += 1;
+      else if (candidateStatus === 'falsified') falsifiedCount += 1;
+      else undecidedCount += 1;
+
+      candidateCosts.push({
+        candidateId: scaledCandidate.id,
+        family: scaledCandidate.family,
+        probeTimings,
+        totalProbeMs,
+        status: candidateStatus,
+      });
+    }
+  }
+
+  const totalRunnerMs = performance.now() - runnerStart;
+  const totalProbeMs = candidateCosts.reduce((sum, c) => sum + c.totalProbeMs, 0);
+  const candidateProbeTimes = candidateCosts.map((c) => c.totalProbeMs).sort((a, b) => a - b);
+  const meanCandidateProbeMs = candidateProbeTimes.length > 0
+    ? candidateProbeTimes.reduce((s, v) => s + v, 0) / candidateProbeTimes.length
+    : 0;
+  const medianCandidateProbeMs = candidateProbeTimes.length > 0
+    ? candidateProbeTimes[Math.floor(candidateProbeTimes.length / 2)]
+    : 0;
+  const maxCandidateProbeMs = candidateProbeTimes.length > 0
+    ? candidateProbeTimes[candidateProbeTimes.length - 1]
+    : 0;
+
+  const probeTypeAggregate = [...probeTypeMap.entries()]
+    .map(([probeId, agg]) => ({
+      probeId,
+      totalMs: agg.totalMs,
+      meanMs: agg.totalMs / agg.invocationCount,
+      invocationCount: agg.invocationCount,
+    }))
+    .sort((a, b) => a.probeId.localeCompare(b.probeId));
+
+  const totalCandidates = candidateCosts.length;
+  const candidatesPerAcceptedConjecture = survivedCount > 0 ? totalCandidates / survivedCount : null;
+
+  return {
+    solverType: CONJECTURE_RUNNER_V1,
+    suite,
+    scaleCandidateCount: totalCandidates,
+    totalRunnerMs,
+    candidates: candidateCosts,
+    survivedCount,
+    falsifiedCount,
+    undecidedCount,
+    candidatesPerAcceptedConjecture,
+    totalProbeMs,
+    meanCandidateProbeMs,
+    medianCandidateProbeMs,
+    maxCandidateProbeMs,
+    probeTypeAggregate,
+  };
 }
 
 /**

--- a/packages/engine/src/simulation/RenderManifold.ts
+++ b/packages/engine/src/simulation/RenderManifold.ts
@@ -1,0 +1,176 @@
+/**
+ * RenderManifold — the RENDER leg of the Conjecture Engine.
+ *
+ * A render manifold is the deterministic, receipt-carrying visible geometry
+ * surface derived from a conjecture run's proof-carrying receipts. The runner
+ * emits discover/prove/RENDER as the full triple under one deterministic
+ * receipt (the paper's core novelty thesis: vs LeanConjecturer / AlphaEvolve /
+ * FunSearch covering one leg each).
+ *
+ * The render-manifold artifact carries:
+ *   - The vertex and element data from each surviving candidate
+ *   - A deterministic SHA-256 invariant-probe hash over the manifold geometry
+ *   - Replay guarantee: same input -> identical hash (F.069)
+ *
+ * @module RenderManifold
+ */
+
+import { hashGeometry, type HashMode } from './hashes';
+import { sha256Bytes } from './sha256';
+import { stableStringify } from './equivalenceRecord';
+import type {
+  ConjectureReceipt,
+  GeometryConjectureCandidate,
+  ConjectureStatus,
+} from './ConjectureEngine';
+
+export const RENDER_MANIFOLD_V1 = 'conjecture.render-manifold.v1' as const;
+export type RenderManifoldSolverType = typeof RENDER_MANIFOLD_V1;
+
+/** A single rendered surface derived from one receipt's geometry. */
+export interface RenderedSurface {
+  candidateId: string;
+  family: string;
+  status: ConjectureStatus;
+  /** Deterministic geometry hash (via hashGeometry). */
+  geometryHash: string;
+  vertexCount: number;
+  elementCount: number;
+  elementArity: 3 | 4 | null;
+  /** SHA-256 of the canonical (vertices, elements) pair — replay-deterministic. */
+  surfaceDigest: string;
+}
+
+/** The RENDER leg output: a receipt-carrying render manifold. */
+export interface RenderManifoldArtifact {
+  solverType: RenderManifoldSolverType;
+  specVersion: 1;
+  /** Which runner receipt key this manifold was derived from. */
+  sourceReceiptKey: string;
+  /** The rendered surfaces, one per surviving/falsified candidate. */
+  surfaces: ReadonlyArray<RenderedSurface>;
+  /** Deterministic SHA-256 invariant-probe hash over the entire manifold. */
+  invariantProbeHash: string;
+  /** The hash mode used (mirrors the runner's hashMode). */
+  hashMode: HashMode;
+  /** Deterministic receipt key for the manifold artifact itself. */
+  receiptKey: string;
+}
+
+/**
+ * Derive a render-manifold artifact from a set of conjecture receipts.
+ *
+ * Each receipt's candidate geometry is rendered into a surface with a
+ * deterministic SHA-256 surface digest. The overall manifold gets an
+ * invariant-probe hash that is replay-deterministic: same inputs always
+ * produce the same hash (F.069).
+ */
+export function renderManifoldFromReceipts(
+  receipts: ReadonlyArray<ConjectureReceipt>,
+  candidates: ReadonlyArray<ReadonlyArray<GeometryConjectureCandidate>>,
+  hashMode: HashMode = 'sha256',
+): RenderManifoldArtifact {
+  const surfaces: RenderedSurface[] = [];
+
+  for (let r = 0; r < receipts.length; r++) {
+    const receipt = receipts[r];
+    const receiptCandidates = candidates[r] ?? [];
+
+    for (const evaluation of receipt.evaluations) {
+      // Find the matching candidate for geometry data
+      const candidate = receiptCandidates.find(
+        (c) => c.id === evaluation.candidateId,
+      );
+
+      // For surviving/falsified candidates with geometry, build a rendered surface
+      if (
+        evaluation.status === 'survived' ||
+        evaluation.status === 'falsified' ||
+        evaluation.status === 'rediscovered' ||
+        evaluation.status === 'undecided'
+      ) {
+        const geometryHash = evaluation.facts.geometryHash;
+        const vertexCount = evaluation.facts.vertexCount;
+        const elementCount = evaluation.facts.elementCount;
+        const elementArity = evaluation.facts.elementArity;
+
+        // Compute surface digest from candidate geometry (deterministic)
+        let surfaceDigest: string;
+        if (candidate) {
+          surfaceDigest = hashGeometry(candidate.vertices, candidate.elements, hashMode);
+        } else {
+          // Fallback: use the geometry hash from facts as the surface digest
+          surfaceDigest = geometryHash;
+        }
+
+        surfaces.push({
+          candidateId: evaluation.candidateId,
+          family: evaluation.family,
+          status: evaluation.status,
+          geometryHash,
+          vertexCount,
+          elementCount,
+          elementArity,
+          surfaceDigest,
+        });
+      }
+    }
+  }
+
+  // Sort surfaces deterministically by candidateId for replay determinism
+  surfaces.sort((a, b) => a.candidateId.localeCompare(b.candidateId));
+
+  // Compute the invariant-probe hash over the entire manifold
+  const manifoldSnapshot = {
+    solverType: RENDER_MANIFOLD_V1,
+    specVersion: 1,
+    surfaces: surfaces.map((s) => ({
+      id: s.candidateId,
+      family: s.family,
+      status: s.status,
+      geometryHash: s.geometryHash,
+      surfaceDigest: s.surfaceDigest,
+      vertexCount: s.vertexCount,
+      elementCount: s.elementCount,
+      elementArity: s.elementArity,
+    })),
+  };
+
+  const invariantProbeHash = `sha-${sha256Bytes(new TextEncoder().encode(stableStringify(manifoldSnapshot)))}`;
+  const sourceReceiptKey = receipts.length > 0 ? receipts[0].receiptKey : 'no-receipt';
+
+  const withoutKey = {
+    solverType: RENDER_MANIFOLD_V1,
+    specVersion: 1 as const,
+    sourceReceiptKey,
+    surfaces,
+    invariantProbeHash,
+    hashMode,
+  };
+
+  return {
+    ...withoutKey,
+    receiptKey: `conjecture.render-manifold.v1-${invariantProbeHash}`,
+  };
+}
+
+/**
+ * Replay-determinism check: run the manifold twice with the same inputs and
+ * verify the invariant-probe hash is identical.
+ *
+ * Returns true if the manifold is replay-deterministic (F.069 guarantee).
+ */
+export function verifyRenderManifoldReplay(
+  receipts: ReadonlyArray<ConjectureReceipt>,
+  candidates: ReadonlyArray<ReadonlyArray<GeometryConjectureCandidate>>,
+  hashMode: HashMode = 'sha256',
+): { passed: boolean; firstHash: string; secondHash: string } {
+  const first = renderManifoldFromReceipts(receipts, candidates, hashMode);
+  const second = renderManifoldFromReceipts(receipts, candidates, hashMode);
+
+  return {
+    passed: first.invariantProbeHash === second.invariantProbeHash && first.receiptKey === second.receiptKey,
+    firstHash: first.invariantProbeHash,
+    secondHash: second.invariantProbeHash,
+  };
+}


### PR DESCRIPTION
## Summary

- Restores `packages/engine/src/simulation/RenderManifold.ts` (175 LOC) and the cost-cell additions to `ConjectureRunner.ts` (+186 LOC) that a 2026-05-26 reconcile dropped while leaving the export blocks in `simulation/index.ts` intact, leaving engine un-buildable.
- Sources verbatim from `refs/heads/codex/main-pre-reconcile-20260526` — the original P36 receipt-manifold feature (commits `dae4db68b` / `ef337bd86`).
- Validated locally: `corepack pnpm --filter @holoscript/engine run build` → zero TS errors, all dist artifacts emitted.

## Test plan

- [x] `corepack pnpm install --frozen-lockfile` succeeds
- [x] `corepack pnpm --filter @holoscript/engine run build` exits 0
- [ ] After merge, `corepack pnpm build` from root completes so `examples/gold-game/drive-build.mjs` can run end-to-end (unblocks Gate-30 verification of the Front Door panel PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)