### PR TITLE
fix(webgpu-capture): NaN sentinel in ε-quantize used fixed constant, not bit pattern

### DIFF
--- a/scripts/webgpu-capture/capture-bench.mjs
+++ b/scripts/webgpu-capture/capture-bench.mjs
@@ -543,18 +543,22 @@ async function runBenchInPage(input) {
 
   async function digestBytes(rawBytes) {
     if (digestMode === 'bit-identical') return sha256Hex(rawBytes);
-    // ε-quantized: reinterpret bytes as f32, divide by ε, floor to int32,
+    // ε-quantized: reinterpret bytes as f32, divide by ε, round to int32,
     // re-emit as int32 byte buffer, then SHA-256. We use a single ε for the
     // whole buffer — appropriate when all elements are in the same numeric
     // regime (e.g. a CG residual vector, an SDF distance field).
     const f32 = new Float32Array(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength / 4);
+    // rawU32 shares the same buffer so NaN bit patterns are readable.
+    const rawU32 = new Uint32Array(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength / 4);
     const quant = new Int32Array(f32.length);
     for (let j = 0; j < f32.length; j++) {
       // Round to nearest int (not floor) so [-ε/2, +ε/2) → 0 symmetric.
-      // NaN handling: any NaN stays as a distinct sentinel so NaN-emitting
-      // kernels show up as digest-unique (correct: NaN is observably broken).
+      // NaN: preserve the raw u32 bit pattern rather than a fixed sentinel.
+      // A kernel that consistently produces the same NaN bits will hash as
+      // ε-identical (deterministic failure); one that produces varying NaN
+      // bit patterns will produce distinct digests (non-deterministic failure).
       const v = f32[j];
-      quant[j] = Number.isNaN(v) ? 0x7fffffff : Math.round(v / epsilon);
+      quant[j] = Number.isNaN(v) ? (rawU32[j] | 0) : Math.round(v / epsilon);
     }
     return sha256Hex(new Uint8Array(quant.buffer));
   }


### PR DESCRIPTION
## Summary

- **Bug**: `digestBytes()` in `capture-bench.mjs` mapped every NaN f32 element to the fixed sentinel `0x7fffffff`. A GPU kernel that consistently outputs NaN would hash identically across trials, so `digest_epsilon_identical` would be `true` — a false pass. The comment claimed "NaN-emitting kernels show up as digest-unique" but the implementation did the opposite.
- **Fix**: Replace the fixed constant with `rawU32[j] | 0` — the actual IEEE-754 bit pattern of the NaN element, cast to int32. Consistent NaN bit patterns now produce consistent (ε-identical) digests; varying NaN bit patterns produce distinct digests. Comment updated to match.

## Root cause

Commit `2068c3d3` (Phase 5 ε-tolerance mode). The intent was correct but the sentinel was a constant rather than the raw bits, so two NaN-valued buffers always collapsed to the same hash regardless of their actual bit patterns.

## Test plan

- [ ] Run `pnpm conjecture:cost-cell` (smoke, no GPU needed) — unaffected by this change
- [ ] Verify epsilon-SAXPY capture still produces `digest_epsilon_identical: true` (f32 values, no NaN)
- [ ] Manual: inject a NaN into a test buffer — `digestBytes` with the new code should produce the same hash for two buffers with the same NaN bit pattern, and a different hash when the NaN bit pattern differs

## Notes for pending board tasks

Two additional bugs found during A-006 hunt that need board tasks filed once `HOLOMESH_API_KEY`/`HOLOMESH_TEAM_ID` are set:

1. **`runConjectureCostCell` ignores `scenario.candidates[1..N]`** (medium) — `ef7fadf7`, `ConjectureRunner.ts:663`. For `GENERATED_GEOMETRY_FAMILY_SUITE` only `candidates[0]` is exercised per scenario; family members beyond the first are silently skipped.
2. **`orphansRemoved` overcounts in steward tick** (low) — `2507a986`, `hololand-mcp-tools.ts:2371`. `orphansRemoved++` fires for detected (not removed) zoneId orphans; variable is computed but never returned in the result.

https://claude.ai/code/session_01RPqx6ZMhc5rJr8vs4FZDM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPqx6ZMhc5rJr8vs4FZDM9)_